### PR TITLE
ci: add go format in github workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,8 @@ jobs:
         run: goimports -w .
 
       - name: Commit and push changes
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --cached --quiet || git commit -m "chore: format Go code via gofmt/goimports"
-          git push origin HEAD:${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: format Go code via gofmt/goimports"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: true
           fetch-depth: 0
 
@@ -28,7 +27,7 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@latest
 
       - name: go format
-        run: gofmt -w .
+        run: goimports -w .
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
         run: goimports -w .
 
       - name: Commit and push changes
+        if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: format Go code via gofmt/goimports"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Format Go Code
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up go version
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24"
+
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+
+      - name: go format
+        run: gofmt -w .
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --cached --quiet || git commit -m "chore: format Go code via gofmt/goimports"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          persist-credentials: true
+          fetch-depth: 0
 
       - name: Set up go version
         uses: actions/setup-go@v4
@@ -32,6 +36,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git diff --cached --quiet || git commit -m "chore: format Go code via gofmt/goimports"
-          git push
+          git push origin HEAD:${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- add github workflow in path ./github/workflows/lint.yml
- if code don't format github action commit and push code version format
- this workflow running before go build #3 

review by copilot : This pull request introduces a new GitHub Actions workflow to automate the formatting of Go code in the repository. The workflow ensures consistent code formatting by using `gofmt` and `goimports` on every push or pull request to the `main` branch.

### Automation of Go code formatting:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R37): Added a new GitHub Actions workflow named "Format Go Code" that runs on `ubuntu-latest`. It sets up Go 1.24, installs `goimports`, formats the code using `gofmt`, and commits and pushes any changes back to the repository.

```yml
name: Format Go Code

on:
  push:
    branches:
      - "main"
  pull_request:
    branches:
      - "main"

jobs:
  format:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v4

      - name: Set up go version
        uses: actions/setup-go@v4
        with:
          go-version: "1.24"

      - name: Install goimports
        run: go install golang.org/x/tools/cmd/goimports@latest

      - name: go format
        run: gofmt -w .

      - name: Commit and push changes
        run: |
          git config --global user.name "github-actions[bot]"
          git config --global user.email "github-actions[bot]@users.noreply.github.com"
          git add .
          git diff --cached --quiet || git commit -m "chore: format Go code via gofmt/goimports"
          git push
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```