### PR TITLE
ci: add workflow auto generate docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: autoGenDocs
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.24
+
+      - name: Install swag CLI
+        run: |
+          go install github.com/swaggo/swag/cmd/swag@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+
+      - name: Generate Swagger docs
+        run: |
+          swag init
+
+      - name: Commit and push docs if changed
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git add docs/
+          if git diff --cached --quiet; then
+            echo "No changes in docs to commit."
+          else
+            git commit -m "Auto update swagger docs"
+            git push origin HEAD:main
+          fi


### PR DESCRIPTION
- เพิ่ม auto generate docs ตอนที่เพิ่ม docs เข้ามา

copilot review : This pull request introduces a new GitHub Actions workflow to automate the generation and updating of Swagger documentation. The workflow is triggered on pushes and pull requests to the `main` branch and ensures that any changes to the generated documentation are automatically committed and pushed.

### Automation of Swagger documentation:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR1-R44): Added a new workflow named `autoGenDocs` that runs on `ubuntu-latest`. It sets up a Go environment (`go-version: 1.24`), installs the `swag` CLI, generates Swagger documentation using `swag init`, and commits and pushes any changes to the `docs/` directory back to the `main` branch.