### PR TITLE
chore(swagger): Refactor API handlers and models to use Doc-only structs for Swagger documentation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -181,10 +181,3100 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/banlearner": {
+            "post": {
+                "description": "CreateBanLearner creates a new ban record for a learner",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Create a new banned learner record",
+                "parameters": [
+                    {
+                        "description": "Ban Learner Payload",
+                        "name": "banlearner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banlearner/{id}": {
+            "get": {
+                "description": "GetBanLearner returns a single ban record by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Get a banned learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateBanLearner modifies an existing ban record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Update a banned learner record",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated ban record",
+                        "name": "banlearner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteBanLearner deletes a ban record by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Delete a banned learner record",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted ban learner",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banlearners": {
+            "get": {
+                "description": "GetBanLearners returns a list of all ban records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Get all banned learners",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.BanDetailsLearner"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteacher": {
+            "post": {
+                "description": "CreateBanTeacher creates a new BanDetailsTeacher entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Create a new ban record for a teacher",
+                "parameters": [
+                    {
+                        "description": "BanTeacher payload",
+                        "name": "banteacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteacher/{id}": {
+            "get": {
+                "description": "GetBanTeacher retrieves a single BanDetailsTeacher by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Get ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateBanTeacher updates an existing BanDetailsTeacher",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Update a ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated payload",
+                        "name": "banteacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteBanTeacher removes a BanDetailsTeacher record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Delete a ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted ban teacher",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteachers": {
+            "get": {
+                "description": "GetBanTeachers retrieves all BanDetailsTeacher entries with associated Teacher",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "List all ban records for teachers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.BanDetailsTeacher"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class": {
+            "post": {
+                "description": "CreateClass creates a new Class record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Create a new class",
+                "parameters": [
+                    {
+                        "description": "Class payload",
+                        "name": "class",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class/{id}": {
+            "get": {
+                "description": "GetClass retrieves a single Class by its ID, including Teacher and Categories",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Get class by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClass updates a Class record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Update an existing class",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated class payload",
+                        "name": "class",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClass removes a Class record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Delete a class by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_categories": {
+            "get": {
+                "description": "GetClassCategories retrieves all ClassCategory records with Classes relation",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "List all class categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClassCategory"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_category": {
+            "post": {
+                "description": "CreateClassCategory creates a new ClassCategory record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Create a new class category",
+                "parameters": [
+                    {
+                        "description": "ClassCategory payload",
+                        "name": "class_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_category/{id}": {
+            "get": {
+                "description": "GetClassCategory retrieves a single ClassCategory by its ID, including Classes",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Get class category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClassCategory updates a ClassCategory record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Update an existing class category",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated payload",
+                        "name": "class_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClassCategory removes a ClassCategory record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Delete a class category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class category",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_session": {
+            "post": {
+                "description": "CreateClassSession creates a new ClassSession record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Create a new class session",
+                "parameters": [
+                    {
+                        "description": "ClassSession payload",
+                        "name": "class_session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_session/{id}": {
+            "get": {
+                "description": "GetClassSession retrieves a single ClassSession by its ID, including Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Get class session by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClassSession updates a ClassSession record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Update an existing class session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated ClassSession payload",
+                        "name": "class_session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClassSession removes a ClassSession record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Delete a class session by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class session",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_sessions": {
+            "get": {
+                "description": "GetClassSessions retrieves all ClassSession records with Class relation",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "List all class sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClassSession"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/classes": {
+            "get": {
+                "description": "GetClasses retrieves all Class records with Teacher and Categories relations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "List all classes",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Class"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollment": {
+            "post": {
+                "description": "CreateEnrollment creates a new Enrollment record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Create a new enrollment",
+                "parameters": [
+                    {
+                        "description": "Enrollment payload",
+                        "name": "enrollment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollment/{id}": {
+            "get": {
+                "description": "GetEnrollment retrieves a single Enrollment by its ID, including related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Get enrollment by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateEnrollment updates an Enrollment record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Update an existing enrollment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated enrollment payload",
+                        "name": "enrollment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteEnrollment removes an Enrollment record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Delete an enrollment by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted enrollment",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollments": {
+            "get": {
+                "description": "GetEnrollments retrieves all Enrollment records with associated Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "List all enrollments",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Enrollment"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learner": {
+            "post": {
+                "description": "CreateLearner creates a new Learner record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Create a new learner",
+                "parameters": [
+                    {
+                        "description": "Learner payload",
+                        "name": "learner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learner/{id}": {
+            "get": {
+                "description": "GetLearner retrieves a single Learner by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Get learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Learner not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteLearner removes a Learner record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Delete a learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Learner",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Learner not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learners": {
+            "get": {
+                "description": "GetLearners retrieves all Learner records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "List all learners",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Learner"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notification": {
+            "post": {
+                "description": "CreateNotification creates a new Notification record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Create a new notification",
+                "parameters": [
+                    {
+                        "description": "Notification payload",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notification/{id}": {
+            "get": {
+                "description": "GetNotification retrieves a single Notification by its ID, including the User",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Get notification by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateNotification updates a Notification record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Update an existing notification",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated notification payload",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteNotification removes a Notification record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Delete a notification by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted notification",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notifications": {
+            "get": {
+                "description": "GetNotifications retrieves all Notification records with associated User",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "List all notifications",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Notification"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/report": {
+            "post": {
+                "description": "CreateReport creates a new Report record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Create a new report",
+                "parameters": [
+                    {
+                        "description": "Report payload",
+                        "name": "report",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/report/{id}": {
+            "get": {
+                "description": "GetReport retrieves a single Report by its ID, including Reporter and Reported",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Get report by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateReport updates a Report record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Update an existing report",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated report payload",
+                        "name": "report",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteReport removes a Report record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Delete a report by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Report",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports": {
+            "get": {
+                "description": "GetReports retrieves all Report records with Reporter and Reported relations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "List all reports",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Report"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/review": {
+            "post": {
+                "description": "CreateReview creates a new Review record with rating validation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Create a new review",
+                "parameters": [
+                    {
+                        "description": "Review payload",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or rating out of range",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/review/{id}": {
+            "get": {
+                "description": "GetReview retrieves a single Review by its ID, including related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Get review by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateReview updates a Review record by its ID; only Rating and Comment fields",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Update an existing review",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated review payload",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or rating out of range",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteReview removes a Review record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Delete a review by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted review",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reviews": {
+            "get": {
+                "description": "GetReviews retrieves all Review records with related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "List all reviews",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Review"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teacher": {
+            "post": {
+                "description": "CreateTeacher creates a new Teacher record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Create a new teacher",
+                "parameters": [
+                    {
+                        "description": "Teacher payload",
+                        "name": "teacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teacher/{id}": {
+            "get": {
+                "description": "GetTeacher retrieves a single Teacher by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Get teacher by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateTeacher updates a Teacher record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Update an existing teacher",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated teacher payload",
+                        "name": "teacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteTeacher removes a Teacher record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Delete a teacher by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Teacher",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teachers": {
+            "get": {
+                "description": "GetTeachers retrieves all Teacher records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "List all teachers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Teacher"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user": {
+            "post": {
+                "description": "CreateUser creates a new user record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Create a new user",
+                "parameters": [
+                    {
+                        "description": "User payload",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user/{id}": {
+            "get": {
+                "description": "GetUser retrieves a single user by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateUser updates a user record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update an existing user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated user payload",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteUser removes a user record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Delete a user by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted User",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users": {
+            "get": {
+                "description": "GetUsers retrieves all user records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "List all users",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.User"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
         "models.Admin": {
+            "type": "object"
+        },
+        "models.BanDetailsLearner": {
+            "type": "object"
+        },
+        "models.BanDetailsTeacher": {
+            "type": "object"
+        },
+        "models.Class": {
+            "type": "object"
+        },
+        "models.ClassCategory": {
+            "type": "object"
+        },
+        "models.ClassSession": {
+            "type": "object"
+        },
+        "models.Enrollment": {
+            "type": "object"
+        },
+        "models.Learner": {
+            "type": "object"
+        },
+        "models.Notification": {
+            "type": "object"
+        },
+        "models.Report": {
+            "type": "object"
+        },
+        "models.Review": {
+            "type": "object"
+        },
+        "models.Teacher": {
+            "type": "object"
+        },
+        "models.User": {
             "type": "object"
         }
     }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -44,7 +44,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     }
                 ],
@@ -52,7 +52,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     },
                     "400": {
@@ -91,7 +91,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     },
                     "400": {
@@ -168,7 +168,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Admin"
+                                "$ref": "#/definitions/models.AdminDoc"
                             }
                         }
                     },
@@ -202,7 +202,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     }
                 ],
@@ -210,7 +210,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -257,7 +257,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -315,7 +315,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     }
                 ],
@@ -323,7 +323,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -426,7 +426,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.BanDetailsLearner"
+                                "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                             }
                         }
                     },
@@ -462,7 +462,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     }
                 ],
@@ -470,7 +470,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -517,7 +517,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -575,7 +575,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     }
                 ],
@@ -583,7 +583,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -686,7 +686,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.BanDetailsTeacher"
+                                "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                             }
                         }
                     },
@@ -722,7 +722,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     }
                 ],
@@ -730,7 +730,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -777,7 +777,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -835,7 +835,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     }
                 ],
@@ -843,7 +843,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -946,7 +946,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClassCategory"
+                                "$ref": "#/definitions/models.ClassCategoryDoc"
                             }
                         }
                     },
@@ -982,7 +982,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     }
                 ],
@@ -990,7 +990,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1037,7 +1037,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1095,7 +1095,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     }
                 ],
@@ -1103,7 +1103,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1210,7 +1210,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     }
                 ],
@@ -1218,7 +1218,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1265,7 +1265,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1323,7 +1323,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     }
                 ],
@@ -1331,7 +1331,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1434,7 +1434,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClassSession"
+                                "$ref": "#/definitions/models.ClassSessionDoc"
                             }
                         }
                     },
@@ -1466,7 +1466,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Class"
+                                "$ref": "#/definitions/models.ClassDoc"
                             }
                         }
                     },
@@ -1502,7 +1502,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     }
                 ],
@@ -1510,7 +1510,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1557,7 +1557,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1615,7 +1615,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     }
                 ],
@@ -1623,7 +1623,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1726,7 +1726,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Enrollment"
+                                "$ref": "#/definitions/models.EnrollmentDoc"
                             }
                         }
                     },
@@ -1762,7 +1762,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     }
                 ],
@@ -1770,7 +1770,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     },
                     "400": {
@@ -1817,7 +1817,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     },
                     "400": {
@@ -1920,7 +1920,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Learner"
+                                "$ref": "#/definitions/models.LearnerDoc"
                             }
                         }
                     },
@@ -1956,7 +1956,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     }
                 ],
@@ -1964,7 +1964,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2011,7 +2011,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2069,7 +2069,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     }
                 ],
@@ -2077,7 +2077,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2180,7 +2180,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Notification"
+                                "$ref": "#/definitions/models.NotificationDoc"
                             }
                         }
                     },
@@ -2216,7 +2216,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     }
                 ],
@@ -2224,7 +2224,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2271,7 +2271,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2329,7 +2329,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     }
                 ],
@@ -2337,7 +2337,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2440,7 +2440,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Report"
+                                "$ref": "#/definitions/models.ReportDoc"
                             }
                         }
                     },
@@ -2476,7 +2476,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     }
                 ],
@@ -2484,7 +2484,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2531,7 +2531,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2589,7 +2589,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     }
                 ],
@@ -2597,7 +2597,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2700,7 +2700,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Review"
+                                "$ref": "#/definitions/models.ReviewDoc"
                             }
                         }
                     },
@@ -2736,7 +2736,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     }
                 ],
@@ -2744,7 +2744,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2791,7 +2791,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2849,7 +2849,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     }
                 ],
@@ -2857,7 +2857,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2960,7 +2960,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Teacher"
+                                "$ref": "#/definitions/models.TeacherDoc"
                             }
                         }
                     },
@@ -2996,7 +2996,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     }
                 ],
@@ -3004,7 +3004,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3051,7 +3051,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3109,7 +3109,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     }
                 ],
@@ -3117,7 +3117,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3220,7 +3220,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.User"
+                                "$ref": "#/definitions/models.UserDoc"
                             }
                         }
                     },
@@ -3238,44 +3238,320 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "models.Admin": {
-            "type": "object"
+        "models.AdminDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 43
+                }
+            }
         },
-        "models.BanDetailsLearner": {
-            "type": "object"
+        "models.BanDetailsLearnerDoc": {
+            "type": "object",
+            "properties": {
+                "ban_description": {
+                    "type": "string",
+                    "example": "Spamming inappropriate content"
+                },
+                "ban_end": {
+                    "type": "string",
+                    "example": "2025-08-30T12:00:00Z"
+                },
+                "ban_start": {
+                    "type": "string",
+                    "example": "2025-08-20T12:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.BanDetailsTeacher": {
-            "type": "object"
+        "models.BanDetailsTeacherDoc": {
+            "type": "object",
+            "properties": {
+                "ban_description": {
+                    "type": "string",
+                    "example": "Repeated policy violations"
+                },
+                "ban_end": {
+                    "type": "string",
+                    "example": "2025-08-30T12:00:00Z"
+                },
+                "ban_start": {
+                    "type": "string",
+                    "example": "2025-08-20T12:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         },
-        "models.Class": {
-            "type": "object"
+        "models.ClassCategoryDoc": {
+            "type": "object",
+            "properties": {
+                "class_category": {
+                    "type": "string",
+                    "example": "Mathematics"
+                },
+                "classes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ClassDoc"
+                    }
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 3
+                }
+            }
         },
-        "models.ClassCategory": {
-            "type": "object"
+        "models.ClassDoc": {
+            "type": "object",
+            "properties": {
+                "class_description": {
+                    "type": "string",
+                    "example": "Advanced Python programming course"
+                },
+                "enrollment_deadline": {
+                    "type": "string",
+                    "example": "2025-09-10T23:59:59Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 21
+                },
+                "learner_limit": {
+                    "type": "integer",
+                    "example": 50
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         },
-        "models.ClassSession": {
-            "type": "object"
+        "models.ClassSessionDoc": {
+            "type": "object",
+            "properties": {
+                "class_finish": {
+                    "type": "string",
+                    "example": "2025-09-05T16:00:00Z"
+                },
+                "class_id": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "class_start": {
+                    "type": "string",
+                    "example": "2025-09-05T14:00:00Z"
+                },
+                "class_status": {
+                    "type": "string",
+                    "example": "Scheduled"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Weekly tutoring session for calculus"
+                },
+                "enrollment_deadline": {
+                    "type": "string",
+                    "example": "2025-09-01T23:59:59Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 15
+                }
+            }
         },
-        "models.Enrollment": {
-            "type": "object"
+        "models.EnrollmentDoc": {
+            "type": "object",
+            "properties": {
+                "class_id": {
+                    "type": "integer",
+                    "example": 21
+                },
+                "enrollment_status": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Learner": {
-            "type": "object"
+        "models.LearnerDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Notification": {
-            "type": "object"
+        "models.NotificationDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "notification_date": {
+                    "type": "string",
+                    "example": "2025-08-20T15:04:05Z"
+                },
+                "notification_description": {
+                    "type": "string",
+                    "example": "Your class has been rescheduled"
+                },
+                "notification_type": {
+                    "type": "string",
+                    "example": "System Alert"
+                },
+                "read_flag": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "user_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Report": {
-            "type": "object"
+        "models.ReportDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "report_date": {
+                    "type": "string",
+                    "example": "2025-08-20T14:30:00Z"
+                },
+                "report_description": {
+                    "type": "string",
+                    "example": "User sent inappropriate messages"
+                },
+                "report_picture": {
+                    "type": "string",
+                    "example": "base64-encoded-image-string"
+                },
+                "report_type": {
+                    "type": "string",
+                    "example": "Abuse"
+                },
+                "report_user_id": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "reported_user_id": {
+                    "type": "integer",
+                    "example": 8
+                }
+            }
         },
-        "models.Review": {
-            "type": "object"
+        "models.ReviewDoc": {
+            "type": "object",
+            "properties": {
+                "class_id": {
+                    "type": "integer",
+                    "example": 9
+                },
+                "comment": {
+                    "type": "string",
+                    "example": "This class was very informative and well-structured."
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "rating": {
+                    "type": "integer",
+                    "example": 5
+                }
+            }
         },
-        "models.Teacher": {
-            "type": "object"
+        "models.TeacherDoc": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Experienced Mathematics teacher specializing in calculus and linear algebra."
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 12
+                }
+            }
         },
-        "models.User": {
-            "type": "object"
+        "models.UserDoc": {
+            "type": "object",
+            "properties": {
+                "admin_id": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "balance": {
+                    "type": "number",
+                    "example": 250.75
+                },
+                "first_name": {
+                    "type": "string",
+                    "example": "Alice"
+                },
+                "gender": {
+                    "type": "string",
+                    "example": "Female"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "last_name": {
+                    "type": "string",
+                    "example": "Smith"
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "phone_number": {
+                    "type": "string",
+                    "example": "+66912345678"
+                },
+                "profile_picture": {
+                    "type": "string",
+                    "example": "\u003cbase64-encoded-image\u003e"
+                },
+                "session_id": {
+                    "type": "string",
+                    "example": "sess-abc123xyz"
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -41,7 +41,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     }
                 ],
@@ -49,7 +49,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     },
                     "400": {
@@ -88,7 +88,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Admin"
+                            "$ref": "#/definitions/models.AdminDoc"
                         }
                     },
                     "400": {
@@ -165,7 +165,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Admin"
+                                "$ref": "#/definitions/models.AdminDoc"
                             }
                         }
                     },
@@ -199,7 +199,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     }
                 ],
@@ -207,7 +207,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -254,7 +254,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -312,7 +312,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     }
                 ],
@@ -320,7 +320,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsLearner"
+                            "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                         }
                     },
                     "400": {
@@ -423,7 +423,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.BanDetailsLearner"
+                                "$ref": "#/definitions/models.BanDetailsLearnerDoc"
                             }
                         }
                     },
@@ -459,7 +459,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     }
                 ],
@@ -467,7 +467,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -514,7 +514,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -572,7 +572,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     }
                 ],
@@ -580,7 +580,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                            "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                         }
                     },
                     "400": {
@@ -683,7 +683,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.BanDetailsTeacher"
+                                "$ref": "#/definitions/models.BanDetailsTeacherDoc"
                             }
                         }
                     },
@@ -719,7 +719,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     }
                 ],
@@ -727,7 +727,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -774,7 +774,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -832,7 +832,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     }
                 ],
@@ -840,7 +840,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "$ref": "#/definitions/models.ClassDoc"
                         }
                     },
                     "400": {
@@ -943,7 +943,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClassCategory"
+                                "$ref": "#/definitions/models.ClassCategoryDoc"
                             }
                         }
                     },
@@ -979,7 +979,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     }
                 ],
@@ -987,7 +987,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1034,7 +1034,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1092,7 +1092,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     }
                 ],
@@ -1100,7 +1100,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassCategory"
+                            "$ref": "#/definitions/models.ClassCategoryDoc"
                         }
                     },
                     "400": {
@@ -1207,7 +1207,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     }
                 ],
@@ -1215,7 +1215,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1262,7 +1262,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1320,7 +1320,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     }
                 ],
@@ -1328,7 +1328,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClassSession"
+                            "$ref": "#/definitions/models.ClassSessionDoc"
                         }
                     },
                     "400": {
@@ -1431,7 +1431,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClassSession"
+                                "$ref": "#/definitions/models.ClassSessionDoc"
                             }
                         }
                     },
@@ -1463,7 +1463,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Class"
+                                "$ref": "#/definitions/models.ClassDoc"
                             }
                         }
                     },
@@ -1499,7 +1499,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     }
                 ],
@@ -1507,7 +1507,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1554,7 +1554,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1612,7 +1612,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     }
                 ],
@@ -1620,7 +1620,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Enrollment"
+                            "$ref": "#/definitions/models.EnrollmentDoc"
                         }
                     },
                     "400": {
@@ -1723,7 +1723,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Enrollment"
+                                "$ref": "#/definitions/models.EnrollmentDoc"
                             }
                         }
                     },
@@ -1759,7 +1759,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     }
                 ],
@@ -1767,7 +1767,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     },
                     "400": {
@@ -1814,7 +1814,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Learner"
+                            "$ref": "#/definitions/models.LearnerDoc"
                         }
                     },
                     "400": {
@@ -1917,7 +1917,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Learner"
+                                "$ref": "#/definitions/models.LearnerDoc"
                             }
                         }
                     },
@@ -1953,7 +1953,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     }
                 ],
@@ -1961,7 +1961,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2008,7 +2008,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2066,7 +2066,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     }
                 ],
@@ -2074,7 +2074,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Notification"
+                            "$ref": "#/definitions/models.NotificationDoc"
                         }
                     },
                     "400": {
@@ -2177,7 +2177,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Notification"
+                                "$ref": "#/definitions/models.NotificationDoc"
                             }
                         }
                     },
@@ -2213,7 +2213,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     }
                 ],
@@ -2221,7 +2221,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2268,7 +2268,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2326,7 +2326,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     }
                 ],
@@ -2334,7 +2334,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Report"
+                            "$ref": "#/definitions/models.ReportDoc"
                         }
                     },
                     "400": {
@@ -2437,7 +2437,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Report"
+                                "$ref": "#/definitions/models.ReportDoc"
                             }
                         }
                     },
@@ -2473,7 +2473,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     }
                 ],
@@ -2481,7 +2481,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2528,7 +2528,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2586,7 +2586,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     }
                 ],
@@ -2594,7 +2594,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Review"
+                            "$ref": "#/definitions/models.ReviewDoc"
                         }
                     },
                     "400": {
@@ -2697,7 +2697,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Review"
+                                "$ref": "#/definitions/models.ReviewDoc"
                             }
                         }
                     },
@@ -2733,7 +2733,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     }
                 ],
@@ -2741,7 +2741,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2788,7 +2788,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2846,7 +2846,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     }
                 ],
@@ -2854,7 +2854,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Teacher"
+                            "$ref": "#/definitions/models.TeacherDoc"
                         }
                     },
                     "400": {
@@ -2957,7 +2957,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Teacher"
+                                "$ref": "#/definitions/models.TeacherDoc"
                             }
                         }
                     },
@@ -2993,7 +2993,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     }
                 ],
@@ -3001,7 +3001,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3048,7 +3048,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3106,7 +3106,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     }
                 ],
@@ -3114,7 +3114,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.User"
+                            "$ref": "#/definitions/models.UserDoc"
                         }
                     },
                     "400": {
@@ -3217,7 +3217,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.User"
+                                "$ref": "#/definitions/models.UserDoc"
                             }
                         }
                     },
@@ -3235,44 +3235,320 @@
         }
     },
     "definitions": {
-        "models.Admin": {
-            "type": "object"
+        "models.AdminDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 43
+                }
+            }
         },
-        "models.BanDetailsLearner": {
-            "type": "object"
+        "models.BanDetailsLearnerDoc": {
+            "type": "object",
+            "properties": {
+                "ban_description": {
+                    "type": "string",
+                    "example": "Spamming inappropriate content"
+                },
+                "ban_end": {
+                    "type": "string",
+                    "example": "2025-08-30T12:00:00Z"
+                },
+                "ban_start": {
+                    "type": "string",
+                    "example": "2025-08-20T12:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.BanDetailsTeacher": {
-            "type": "object"
+        "models.BanDetailsTeacherDoc": {
+            "type": "object",
+            "properties": {
+                "ban_description": {
+                    "type": "string",
+                    "example": "Repeated policy violations"
+                },
+                "ban_end": {
+                    "type": "string",
+                    "example": "2025-08-30T12:00:00Z"
+                },
+                "ban_start": {
+                    "type": "string",
+                    "example": "2025-08-20T12:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         },
-        "models.Class": {
-            "type": "object"
+        "models.ClassCategoryDoc": {
+            "type": "object",
+            "properties": {
+                "class_category": {
+                    "type": "string",
+                    "example": "Mathematics"
+                },
+                "classes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ClassDoc"
+                    }
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 3
+                }
+            }
         },
-        "models.ClassCategory": {
-            "type": "object"
+        "models.ClassDoc": {
+            "type": "object",
+            "properties": {
+                "class_description": {
+                    "type": "string",
+                    "example": "Advanced Python programming course"
+                },
+                "enrollment_deadline": {
+                    "type": "string",
+                    "example": "2025-09-10T23:59:59Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 21
+                },
+                "learner_limit": {
+                    "type": "integer",
+                    "example": 50
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         },
-        "models.ClassSession": {
-            "type": "object"
+        "models.ClassSessionDoc": {
+            "type": "object",
+            "properties": {
+                "class_finish": {
+                    "type": "string",
+                    "example": "2025-09-05T16:00:00Z"
+                },
+                "class_id": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "class_start": {
+                    "type": "string",
+                    "example": "2025-09-05T14:00:00Z"
+                },
+                "class_status": {
+                    "type": "string",
+                    "example": "Scheduled"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Weekly tutoring session for calculus"
+                },
+                "enrollment_deadline": {
+                    "type": "string",
+                    "example": "2025-09-01T23:59:59Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 15
+                }
+            }
         },
-        "models.Enrollment": {
-            "type": "object"
+        "models.EnrollmentDoc": {
+            "type": "object",
+            "properties": {
+                "class_id": {
+                    "type": "integer",
+                    "example": 21
+                },
+                "enrollment_status": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Learner": {
-            "type": "object"
+        "models.LearnerDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Notification": {
-            "type": "object"
+        "models.NotificationDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "notification_date": {
+                    "type": "string",
+                    "example": "2025-08-20T15:04:05Z"
+                },
+                "notification_description": {
+                    "type": "string",
+                    "example": "Your class has been rescheduled"
+                },
+                "notification_type": {
+                    "type": "string",
+                    "example": "System Alert"
+                },
+                "read_flag": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "user_id": {
+                    "type": "integer",
+                    "example": 42
+                }
+            }
         },
-        "models.Report": {
-            "type": "object"
+        "models.ReportDoc": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "report_date": {
+                    "type": "string",
+                    "example": "2025-08-20T14:30:00Z"
+                },
+                "report_description": {
+                    "type": "string",
+                    "example": "User sent inappropriate messages"
+                },
+                "report_picture": {
+                    "type": "string",
+                    "example": "base64-encoded-image-string"
+                },
+                "report_type": {
+                    "type": "string",
+                    "example": "Abuse"
+                },
+                "report_user_id": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "reported_user_id": {
+                    "type": "integer",
+                    "example": 8
+                }
+            }
         },
-        "models.Review": {
-            "type": "object"
+        "models.ReviewDoc": {
+            "type": "object",
+            "properties": {
+                "class_id": {
+                    "type": "integer",
+                    "example": 9
+                },
+                "comment": {
+                    "type": "string",
+                    "example": "This class was very informative and well-structured."
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "rating": {
+                    "type": "integer",
+                    "example": 5
+                }
+            }
         },
-        "models.Teacher": {
-            "type": "object"
+        "models.TeacherDoc": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Experienced Mathematics teacher specializing in calculus and linear algebra."
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 12
+                }
+            }
         },
-        "models.User": {
-            "type": "object"
+        "models.UserDoc": {
+            "type": "object",
+            "properties": {
+                "admin_id": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "balance": {
+                    "type": "number",
+                    "example": 250.75
+                },
+                "first_name": {
+                    "type": "string",
+                    "example": "Alice"
+                },
+                "gender": {
+                    "type": "string",
+                    "example": "Female"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 101
+                },
+                "last_name": {
+                    "type": "string",
+                    "example": "Smith"
+                },
+                "learner_id": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "phone_number": {
+                    "type": "string",
+                    "example": "+66912345678"
+                },
+                "profile_picture": {
+                    "type": "string",
+                    "example": "\u003cbase64-encoded-image\u003e"
+                },
+                "session_id": {
+                    "type": "string",
+                    "example": "sess-abc123xyz"
+                },
+                "teacher_id": {
+                    "type": "integer",
+                    "example": 7
+                }
+            }
         }
     }
 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -178,10 +178,3100 @@
                     }
                 }
             }
+        },
+        "/banlearner": {
+            "post": {
+                "description": "CreateBanLearner creates a new ban record for a learner",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Create a new banned learner record",
+                "parameters": [
+                    {
+                        "description": "Ban Learner Payload",
+                        "name": "banlearner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banlearner/{id}": {
+            "get": {
+                "description": "GetBanLearner returns a single ban record by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Get a banned learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateBanLearner modifies an existing ban record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Update a banned learner record",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated ban record",
+                        "name": "banlearner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsLearner"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteBanLearner deletes a ban record by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Delete a banned learner record",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Ban Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted ban learner",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banlearners": {
+            "get": {
+                "description": "GetBanLearners returns a list of all ban records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanLearners"
+                ],
+                "summary": "Get all banned learners",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.BanDetailsLearner"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteacher": {
+            "post": {
+                "description": "CreateBanTeacher creates a new BanDetailsTeacher entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Create a new ban record for a teacher",
+                "parameters": [
+                    {
+                        "description": "BanTeacher payload",
+                        "name": "banteacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteacher/{id}": {
+            "get": {
+                "description": "GetBanTeacher retrieves a single BanDetailsTeacher by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Get ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateBanTeacher updates an existing BanDetailsTeacher",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Update a ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated payload",
+                        "name": "banteacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.BanDetailsTeacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteBanTeacher removes a BanDetailsTeacher record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "Delete a ban record by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "BanTeacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted ban teacher",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "BanTeacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/banteachers": {
+            "get": {
+                "description": "GetBanTeachers retrieves all BanDetailsTeacher entries with associated Teacher",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "BanTeachers"
+                ],
+                "summary": "List all ban records for teachers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.BanDetailsTeacher"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class": {
+            "post": {
+                "description": "CreateClass creates a new Class record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Create a new class",
+                "parameters": [
+                    {
+                        "description": "Class payload",
+                        "name": "class",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class/{id}": {
+            "get": {
+                "description": "GetClass retrieves a single Class by its ID, including Teacher and Categories",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Get class by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClass updates a Class record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Update an existing class",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated class payload",
+                        "name": "class",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Class"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClass removes a Class record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "Delete a class by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Class ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Class not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_categories": {
+            "get": {
+                "description": "GetClassCategories retrieves all ClassCategory records with Classes relation",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "List all class categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClassCategory"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_category": {
+            "post": {
+                "description": "CreateClassCategory creates a new ClassCategory record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Create a new class category",
+                "parameters": [
+                    {
+                        "description": "ClassCategory payload",
+                        "name": "class_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_category/{id}": {
+            "get": {
+                "description": "GetClassCategory retrieves a single ClassCategory by its ID, including Classes",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Get class category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClassCategory updates a ClassCategory record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Update an existing class category",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated payload",
+                        "name": "class_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassCategory"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClassCategory removes a ClassCategory record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassCategories"
+                ],
+                "summary": "Delete a class category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassCategory ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class category",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassCategory not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_session": {
+            "post": {
+                "description": "CreateClassSession creates a new ClassSession record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Create a new class session",
+                "parameters": [
+                    {
+                        "description": "ClassSession payload",
+                        "name": "class_session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_session/{id}": {
+            "get": {
+                "description": "GetClassSession retrieves a single ClassSession by its ID, including Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Get class session by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateClassSession updates a ClassSession record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Update an existing class session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated ClassSession payload",
+                        "name": "class_session",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ClassSession"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteClassSession removes a ClassSession record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "Delete a class session by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ClassSession ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted class session",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "ClassSession not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/class_sessions": {
+            "get": {
+                "description": "GetClassSessions retrieves all ClassSession records with Class relation",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClassSessions"
+                ],
+                "summary": "List all class sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClassSession"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/classes": {
+            "get": {
+                "description": "GetClasses retrieves all Class records with Teacher and Categories relations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Classes"
+                ],
+                "summary": "List all classes",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Class"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollment": {
+            "post": {
+                "description": "CreateEnrollment creates a new Enrollment record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Create a new enrollment",
+                "parameters": [
+                    {
+                        "description": "Enrollment payload",
+                        "name": "enrollment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollment/{id}": {
+            "get": {
+                "description": "GetEnrollment retrieves a single Enrollment by its ID, including related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Get enrollment by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateEnrollment updates an Enrollment record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Update an existing enrollment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated enrollment payload",
+                        "name": "enrollment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Enrollment"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteEnrollment removes an Enrollment record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "Delete an enrollment by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Enrollment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted enrollment",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Enrollment not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enrollments": {
+            "get": {
+                "description": "GetEnrollments retrieves all Enrollment records with associated Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enrollments"
+                ],
+                "summary": "List all enrollments",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Enrollment"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learner": {
+            "post": {
+                "description": "CreateLearner creates a new Learner record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Create a new learner",
+                "parameters": [
+                    {
+                        "description": "Learner payload",
+                        "name": "learner",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learner/{id}": {
+            "get": {
+                "description": "GetLearner retrieves a single Learner by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Get learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Learner"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Learner not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteLearner removes a Learner record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "Delete a learner by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Learner ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Learner",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Learner not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learners": {
+            "get": {
+                "description": "GetLearners retrieves all Learner records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Learners"
+                ],
+                "summary": "List all learners",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Learner"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notification": {
+            "post": {
+                "description": "CreateNotification creates a new Notification record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Create a new notification",
+                "parameters": [
+                    {
+                        "description": "Notification payload",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notification/{id}": {
+            "get": {
+                "description": "GetNotification retrieves a single Notification by its ID, including the User",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Get notification by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateNotification updates a Notification record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Update an existing notification",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated notification payload",
+                        "name": "notification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteNotification removes a Notification record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Delete a notification by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Notification ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted notification",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Notification not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notifications": {
+            "get": {
+                "description": "GetNotifications retrieves all Notification records with associated User",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "List all notifications",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Notification"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/report": {
+            "post": {
+                "description": "CreateReport creates a new Report record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Create a new report",
+                "parameters": [
+                    {
+                        "description": "Report payload",
+                        "name": "report",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/report/{id}": {
+            "get": {
+                "description": "GetReport retrieves a single Report by its ID, including Reporter and Reported",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Get report by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateReport updates a Report record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Update an existing report",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated report payload",
+                        "name": "report",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Report"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteReport removes a Report record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Delete a report by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Report ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Report",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Report not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports": {
+            "get": {
+                "description": "GetReports retrieves all Report records with Reporter and Reported relations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "List all reports",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Report"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/review": {
+            "post": {
+                "description": "CreateReview creates a new Review record with rating validation",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Create a new review",
+                "parameters": [
+                    {
+                        "description": "Review payload",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or rating out of range",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/review/{id}": {
+            "get": {
+                "description": "GetReview retrieves a single Review by its ID, including related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Get review by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateReview updates a Review record by its ID; only Rating and Comment fields",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Update an existing review",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated review payload",
+                        "name": "review",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Review"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input or rating out of range",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteReview removes a Review record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "Delete a review by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Review ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted review",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Review not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reviews": {
+            "get": {
+                "description": "GetReviews retrieves all Review records with related Learner and Class",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reviews"
+                ],
+                "summary": "List all reviews",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Review"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teacher": {
+            "post": {
+                "description": "CreateTeacher creates a new Teacher record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Create a new teacher",
+                "parameters": [
+                    {
+                        "description": "Teacher payload",
+                        "name": "teacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teacher/{id}": {
+            "get": {
+                "description": "GetTeacher retrieves a single Teacher by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Get teacher by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateTeacher updates a Teacher record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Update an existing teacher",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated teacher payload",
+                        "name": "teacher",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Teacher"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteTeacher removes a Teacher record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "Delete a teacher by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Teacher ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted Teacher",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Teacher not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teachers": {
+            "get": {
+                "description": "GetTeachers retrieves all Teacher records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teachers"
+                ],
+                "summary": "List all teachers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Teacher"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user": {
+            "post": {
+                "description": "CreateUser creates a new user record",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Create a new user",
+                "parameters": [
+                    {
+                        "description": "User payload",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user/{id}": {
+            "get": {
+                "description": "GetUser retrieves a single user by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "UpdateUser updates a user record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update an existing user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated user payload",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "DeleteUser removes a user record by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Delete a user by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted User",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/users": {
+            "get": {
+                "description": "GetUsers retrieves all user records",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "List all users",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.User"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
         "models.Admin": {
+            "type": "object"
+        },
+        "models.BanDetailsLearner": {
+            "type": "object"
+        },
+        "models.BanDetailsTeacher": {
+            "type": "object"
+        },
+        "models.Class": {
+            "type": "object"
+        },
+        "models.ClassCategory": {
+            "type": "object"
+        },
+        "models.ClassSession": {
+            "type": "object"
+        },
+        "models.Enrollment": {
+            "type": "object"
+        },
+        "models.Learner": {
+            "type": "object"
+        },
+        "models.Notification": {
+            "type": "object"
+        },
+        "models.Report": {
+            "type": "object"
+        },
+        "models.Review": {
+            "type": "object"
+        },
+        "models.Teacher": {
+            "type": "object"
+        },
+        "models.User": {
             "type": "object"
         }
     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,30 @@
 definitions:
   models.Admin:
     type: object
+  models.BanDetailsLearner:
+    type: object
+  models.BanDetailsTeacher:
+    type: object
+  models.Class:
+    type: object
+  models.ClassCategory:
+    type: object
+  models.ClassSession:
+    type: object
+  models.Enrollment:
+    type: object
+  models.Learner:
+    type: object
+  models.Notification:
+    type: object
+  models.Report:
+    type: object
+  models.Review:
+    type: object
+  models.Teacher:
+    type: object
+  models.User:
+    type: object
 host: localhost:8000
 info:
   contact:
@@ -121,6 +145,2042 @@ paths:
       summary: Get all admins
       tags:
       - admins
+  /banlearner:
+    post:
+      consumes:
+      - application/json
+      description: CreateBanLearner creates a new ban record for a learner
+      parameters:
+      - description: Ban Learner Payload
+        in: body
+        name: banlearner
+        required: true
+        schema:
+          $ref: '#/definitions/models.BanDetailsLearner'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.BanDetailsLearner'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new banned learner record
+      tags:
+      - BanLearners
+  /banlearner/{id}:
+    delete:
+      description: DeleteBanLearner deletes a ban record by ID
+      parameters:
+      - description: Ban Learner ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted ban learner
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a banned learner record
+      tags:
+      - BanLearners
+    get:
+      description: GetBanLearner returns a single ban record by ID
+      parameters:
+      - description: Ban Learner ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.BanDetailsLearner'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get a banned learner by ID
+      tags:
+      - BanLearners
+    put:
+      consumes:
+      - application/json
+      description: UpdateBanLearner modifies an existing ban record
+      parameters:
+      - description: Ban Learner ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated ban record
+        in: body
+        name: banlearner
+        required: true
+        schema:
+          $ref: '#/definitions/models.BanDetailsLearner'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.BanDetailsLearner'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update a banned learner record
+      tags:
+      - BanLearners
+  /banlearners:
+    get:
+      description: GetBanLearners returns a list of all ban records
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.BanDetailsLearner'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get all banned learners
+      tags:
+      - BanLearners
+  /banteacher:
+    post:
+      consumes:
+      - application/json
+      description: CreateBanTeacher creates a new BanDetailsTeacher entry
+      parameters:
+      - description: BanTeacher payload
+        in: body
+        name: banteacher
+        required: true
+        schema:
+          $ref: '#/definitions/models.BanDetailsTeacher'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.BanDetailsTeacher'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new ban record for a teacher
+      tags:
+      - BanTeachers
+  /banteacher/{id}:
+    delete:
+      description: DeleteBanTeacher removes a BanDetailsTeacher record by its ID
+      parameters:
+      - description: BanTeacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted ban teacher
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: BanTeacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a ban record by ID
+      tags:
+      - BanTeachers
+    get:
+      description: GetBanTeacher retrieves a single BanDetailsTeacher by its ID
+      parameters:
+      - description: BanTeacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.BanDetailsTeacher'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: BanTeacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get ban record by ID
+      tags:
+      - BanTeachers
+    put:
+      consumes:
+      - application/json
+      description: UpdateBanTeacher updates an existing BanDetailsTeacher
+      parameters:
+      - description: BanTeacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated payload
+        in: body
+        name: banteacher
+        required: true
+        schema:
+          $ref: '#/definitions/models.BanDetailsTeacher'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.BanDetailsTeacher'
+        "400":
+          description: Invalid input or not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: BanTeacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update a ban record by ID
+      tags:
+      - BanTeachers
+  /banteachers:
+    get:
+      description: GetBanTeachers retrieves all BanDetailsTeacher entries with associated
+        Teacher
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.BanDetailsTeacher'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all ban records for teachers
+      tags:
+      - BanTeachers
+  /class:
+    post:
+      consumes:
+      - application/json
+      description: CreateClass creates a new Class record
+      parameters:
+      - description: Class payload
+        in: body
+        name: class
+        required: true
+        schema:
+          $ref: '#/definitions/models.Class'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Class'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new class
+      tags:
+      - Classes
+  /class/{id}:
+    delete:
+      description: DeleteClass removes a Class record by its ID
+      parameters:
+      - description: Class ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted class
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Class not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a class by ID
+      tags:
+      - Classes
+    get:
+      description: GetClass retrieves a single Class by its ID, including Teacher
+        and Categories
+      parameters:
+      - description: Class ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Class'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Class not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get class by ID
+      tags:
+      - Classes
+    put:
+      consumes:
+      - application/json
+      description: UpdateClass updates a Class record by its ID
+      parameters:
+      - description: Class ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated class payload
+        in: body
+        name: class
+        required: true
+        schema:
+          $ref: '#/definitions/models.Class'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Class'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Class not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing class
+      tags:
+      - Classes
+  /class_categories:
+    get:
+      description: GetClassCategories retrieves all ClassCategory records with Classes
+        relation
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.ClassCategory'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all class categories
+      tags:
+      - ClassCategories
+  /class_category:
+    post:
+      consumes:
+      - application/json
+      description: CreateClassCategory creates a new ClassCategory record
+      parameters:
+      - description: ClassCategory payload
+        in: body
+        name: class_category
+        required: true
+        schema:
+          $ref: '#/definitions/models.ClassCategory'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.ClassCategory'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new class category
+      tags:
+      - ClassCategories
+  /class_category/{id}:
+    delete:
+      description: DeleteClassCategory removes a ClassCategory record by its ID
+      parameters:
+      - description: ClassCategory ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted class category
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassCategory not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a class category by ID
+      tags:
+      - ClassCategories
+    get:
+      description: GetClassCategory retrieves a single ClassCategory by its ID, including
+        Classes
+      parameters:
+      - description: ClassCategory ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ClassCategory'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassCategory not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get class category by ID
+      tags:
+      - ClassCategories
+    put:
+      consumes:
+      - application/json
+      description: UpdateClassCategory updates a ClassCategory record by its ID
+      parameters:
+      - description: ClassCategory ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated payload
+        in: body
+        name: class_category
+        required: true
+        schema:
+          $ref: '#/definitions/models.ClassCategory'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ClassCategory'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassCategory not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing class category
+      tags:
+      - ClassCategories
+  /class_session:
+    post:
+      consumes:
+      - application/json
+      description: CreateClassSession creates a new ClassSession record
+      parameters:
+      - description: ClassSession payload
+        in: body
+        name: class_session
+        required: true
+        schema:
+          $ref: '#/definitions/models.ClassSession'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.ClassSession'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new class session
+      tags:
+      - ClassSessions
+  /class_session/{id}:
+    delete:
+      description: DeleteClassSession removes a ClassSession record by its ID
+      parameters:
+      - description: ClassSession ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted class session
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassSession not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a class session by ID
+      tags:
+      - ClassSessions
+    get:
+      description: GetClassSession retrieves a single ClassSession by its ID, including
+        Class
+      parameters:
+      - description: ClassSession ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ClassSession'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassSession not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get class session by ID
+      tags:
+      - ClassSessions
+    put:
+      consumes:
+      - application/json
+      description: UpdateClassSession updates a ClassSession record by its ID
+      parameters:
+      - description: ClassSession ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated ClassSession payload
+        in: body
+        name: class_session
+        required: true
+        schema:
+          $ref: '#/definitions/models.ClassSession'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ClassSession'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: ClassSession not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing class session
+      tags:
+      - ClassSessions
+  /class_sessions:
+    get:
+      description: GetClassSessions retrieves all ClassSession records with Class
+        relation
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.ClassSession'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all class sessions
+      tags:
+      - ClassSessions
+  /classes:
+    get:
+      description: GetClasses retrieves all Class records with Teacher and Categories
+        relations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Class'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all classes
+      tags:
+      - Classes
+  /enrollment:
+    post:
+      consumes:
+      - application/json
+      description: CreateEnrollment creates a new Enrollment record
+      parameters:
+      - description: Enrollment payload
+        in: body
+        name: enrollment
+        required: true
+        schema:
+          $ref: '#/definitions/models.Enrollment'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Enrollment'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new enrollment
+      tags:
+      - Enrollments
+  /enrollment/{id}:
+    delete:
+      description: DeleteEnrollment removes an Enrollment record by its ID
+      parameters:
+      - description: Enrollment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted enrollment
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Enrollment not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete an enrollment by ID
+      tags:
+      - Enrollments
+    get:
+      description: GetEnrollment retrieves a single Enrollment by its ID, including
+        related Learner and Class
+      parameters:
+      - description: Enrollment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Enrollment'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Enrollment not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get enrollment by ID
+      tags:
+      - Enrollments
+    put:
+      consumes:
+      - application/json
+      description: UpdateEnrollment updates an Enrollment record by its ID
+      parameters:
+      - description: Enrollment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated enrollment payload
+        in: body
+        name: enrollment
+        required: true
+        schema:
+          $ref: '#/definitions/models.Enrollment'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Enrollment'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Enrollment not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing enrollment
+      tags:
+      - Enrollments
+  /enrollments:
+    get:
+      description: GetEnrollments retrieves all Enrollment records with associated
+        Learner and Class
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Enrollment'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all enrollments
+      tags:
+      - Enrollments
+  /learner:
+    post:
+      consumes:
+      - application/json
+      description: CreateLearner creates a new Learner record
+      parameters:
+      - description: Learner payload
+        in: body
+        name: learner
+        required: true
+        schema:
+          $ref: '#/definitions/models.Learner'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Learner'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new learner
+      tags:
+      - Learners
+  /learner/{id}:
+    delete:
+      description: DeleteLearner removes a Learner record by its ID
+      parameters:
+      - description: Learner ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted Learner
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Learner not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a learner by ID
+      tags:
+      - Learners
+    get:
+      description: GetLearner retrieves a single Learner by its ID
+      parameters:
+      - description: Learner ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Learner'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Learner not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get learner by ID
+      tags:
+      - Learners
+  /learners:
+    get:
+      description: GetLearners retrieves all Learner records
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Learner'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all learners
+      tags:
+      - Learners
+  /notification:
+    post:
+      consumes:
+      - application/json
+      description: CreateNotification creates a new Notification record
+      parameters:
+      - description: Notification payload
+        in: body
+        name: notification
+        required: true
+        schema:
+          $ref: '#/definitions/models.Notification'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Notification'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new notification
+      tags:
+      - Notifications
+  /notification/{id}:
+    delete:
+      description: DeleteNotification removes a Notification record by its ID
+      parameters:
+      - description: Notification ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted notification
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Notification not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a notification by ID
+      tags:
+      - Notifications
+    get:
+      description: GetNotification retrieves a single Notification by its ID, including
+        the User
+      parameters:
+      - description: Notification ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Notification'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Notification not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get notification by ID
+      tags:
+      - Notifications
+    put:
+      consumes:
+      - application/json
+      description: UpdateNotification updates a Notification record by its ID
+      parameters:
+      - description: Notification ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated notification payload
+        in: body
+        name: notification
+        required: true
+        schema:
+          $ref: '#/definitions/models.Notification'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Notification'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Notification not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing notification
+      tags:
+      - Notifications
+  /notifications:
+    get:
+      description: GetNotifications retrieves all Notification records with associated
+        User
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Notification'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all notifications
+      tags:
+      - Notifications
+  /report:
+    post:
+      consumes:
+      - application/json
+      description: CreateReport creates a new Report record
+      parameters:
+      - description: Report payload
+        in: body
+        name: report
+        required: true
+        schema:
+          $ref: '#/definitions/models.Report'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Report'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new report
+      tags:
+      - Reports
+  /report/{id}:
+    delete:
+      description: DeleteReport removes a Report record by its ID
+      parameters:
+      - description: Report ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted Report
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Report not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a report by ID
+      tags:
+      - Reports
+    get:
+      description: GetReport retrieves a single Report by its ID, including Reporter
+        and Reported
+      parameters:
+      - description: Report ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Report'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Report not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get report by ID
+      tags:
+      - Reports
+    put:
+      consumes:
+      - application/json
+      description: UpdateReport updates a Report record by its ID
+      parameters:
+      - description: Report ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated report payload
+        in: body
+        name: report
+        required: true
+        schema:
+          $ref: '#/definitions/models.Report'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Report'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Report not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing report
+      tags:
+      - Reports
+  /reports:
+    get:
+      description: GetReports retrieves all Report records with Reporter and Reported
+        relations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Report'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all reports
+      tags:
+      - Reports
+  /review:
+    post:
+      consumes:
+      - application/json
+      description: CreateReview creates a new Review record with rating validation
+      parameters:
+      - description: Review payload
+        in: body
+        name: review
+        required: true
+        schema:
+          $ref: '#/definitions/models.Review'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Review'
+        "400":
+          description: Invalid input or rating out of range
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new review
+      tags:
+      - Reviews
+  /review/{id}:
+    delete:
+      description: DeleteReview removes a Review record by its ID
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted review
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Review not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a review by ID
+      tags:
+      - Reviews
+    get:
+      description: GetReview retrieves a single Review by its ID, including related
+        Learner and Class
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Review'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Review not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get review by ID
+      tags:
+      - Reviews
+    put:
+      consumes:
+      - application/json
+      description: UpdateReview updates a Review record by its ID; only Rating and
+        Comment fields
+      parameters:
+      - description: Review ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated review payload
+        in: body
+        name: review
+        required: true
+        schema:
+          $ref: '#/definitions/models.Review'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Review'
+        "400":
+          description: Invalid input or rating out of range
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Review not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing review
+      tags:
+      - Reviews
+  /reviews:
+    get:
+      description: GetReviews retrieves all Review records with related Learner and
+        Class
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Review'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all reviews
+      tags:
+      - Reviews
+  /teacher:
+    post:
+      consumes:
+      - application/json
+      description: CreateTeacher creates a new Teacher record
+      parameters:
+      - description: Teacher payload
+        in: body
+        name: teacher
+        required: true
+        schema:
+          $ref: '#/definitions/models.Teacher'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Teacher'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new teacher
+      tags:
+      - Teachers
+  /teacher/{id}:
+    delete:
+      description: DeleteTeacher removes a Teacher record by its ID
+      parameters:
+      - description: Teacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted Teacher
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Teacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a teacher by ID
+      tags:
+      - Teachers
+    get:
+      description: GetTeacher retrieves a single Teacher by its ID
+      parameters:
+      - description: Teacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Teacher'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Teacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get teacher by ID
+      tags:
+      - Teachers
+    put:
+      consumes:
+      - application/json
+      description: UpdateTeacher updates a Teacher record by its ID
+      parameters:
+      - description: Teacher ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated teacher payload
+        in: body
+        name: teacher
+        required: true
+        schema:
+          $ref: '#/definitions/models.Teacher'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Teacher'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Teacher not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing teacher
+      tags:
+      - Teachers
+  /teachers:
+    get:
+      description: GetTeachers retrieves all Teacher records
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Teacher'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all teachers
+      tags:
+      - Teachers
+  /user:
+    post:
+      consumes:
+      - application/json
+      description: CreateUser creates a new user record
+      parameters:
+      - description: User payload
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/models.User'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.User'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a new user
+      tags:
+      - Users
+  /user/{id}:
+    delete:
+      description: DeleteUser removes a user record by its ID
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted User
+          schema:
+            type: string
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a user by ID
+      tags:
+      - Users
+    get:
+      description: GetUser retrieves a single user by its ID
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.User'
+        "400":
+          description: Invalid ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get user by ID
+      tags:
+      - Users
+    put:
+      consumes:
+      - application/json
+      description: UpdateUser updates a user record by its ID
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated user payload
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/models.User'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.User'
+        "400":
+          description: Invalid input
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Update an existing user
+      tags:
+      - Users
+  /users:
+    get:
+      description: GetUsers retrieves all user records
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.User'
+            type: array
+        "500":
+          description: Server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List all users
+      tags:
+      - Users
 schemes:
 - http
 - https

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,29 +1,230 @@
 definitions:
-  models.Admin:
+  models.AdminDoc:
+    properties:
+      id:
+        example: 43
+        type: integer
     type: object
-  models.BanDetailsLearner:
+  models.BanDetailsLearnerDoc:
+    properties:
+      ban_description:
+        example: Spamming inappropriate content
+        type: string
+      ban_end:
+        example: "2025-08-30T12:00:00Z"
+        type: string
+      ban_start:
+        example: "2025-08-20T12:00:00Z"
+        type: string
+      id:
+        example: 1
+        type: integer
+      learner_id:
+        example: 42
+        type: integer
     type: object
-  models.BanDetailsTeacher:
+  models.BanDetailsTeacherDoc:
+    properties:
+      ban_description:
+        example: Repeated policy violations
+        type: string
+      ban_end:
+        example: "2025-08-30T12:00:00Z"
+        type: string
+      ban_start:
+        example: "2025-08-20T12:00:00Z"
+        type: string
+      id:
+        example: 1
+        type: integer
+      teacher_id:
+        example: 7
+        type: integer
     type: object
-  models.Class:
+  models.ClassCategoryDoc:
+    properties:
+      class_category:
+        example: Mathematics
+        type: string
+      classes:
+        items:
+          $ref: '#/definitions/models.ClassDoc'
+        type: array
+      id:
+        example: 3
+        type: integer
     type: object
-  models.ClassCategory:
+  models.ClassDoc:
+    properties:
+      class_description:
+        example: Advanced Python programming course
+        type: string
+      enrollment_deadline:
+        example: "2025-09-10T23:59:59Z"
+        type: string
+      id:
+        example: 21
+        type: integer
+      learner_limit:
+        example: 50
+        type: integer
+      teacher_id:
+        example: 7
+        type: integer
     type: object
-  models.ClassSession:
+  models.ClassSessionDoc:
+    properties:
+      class_finish:
+        example: "2025-09-05T16:00:00Z"
+        type: string
+      class_id:
+        example: 12
+        type: integer
+      class_start:
+        example: "2025-09-05T14:00:00Z"
+        type: string
+      class_status:
+        example: Scheduled
+        type: string
+      description:
+        example: Weekly tutoring session for calculus
+        type: string
+      enrollment_deadline:
+        example: "2025-09-01T23:59:59Z"
+        type: string
+      id:
+        example: 15
+        type: integer
     type: object
-  models.Enrollment:
+  models.EnrollmentDoc:
+    properties:
+      class_id:
+        example: 21
+        type: integer
+      enrollment_status:
+        example: active
+        type: string
+      id:
+        example: 101
+        type: integer
+      learner_id:
+        example: 42
+        type: integer
     type: object
-  models.Learner:
+  models.LearnerDoc:
+    properties:
+      id:
+        example: 42
+        type: integer
     type: object
-  models.Notification:
+  models.NotificationDoc:
+    properties:
+      id:
+        example: 100
+        type: integer
+      notification_date:
+        example: "2025-08-20T15:04:05Z"
+        type: string
+      notification_description:
+        example: Your class has been rescheduled
+        type: string
+      notification_type:
+        example: System Alert
+        type: string
+      read_flag:
+        example: false
+        type: boolean
+      user_id:
+        example: 42
+        type: integer
     type: object
-  models.Report:
+  models.ReportDoc:
+    properties:
+      id:
+        example: 12
+        type: integer
+      report_date:
+        example: "2025-08-20T14:30:00Z"
+        type: string
+      report_description:
+        example: User sent inappropriate messages
+        type: string
+      report_picture:
+        example: base64-encoded-image-string
+        type: string
+      report_type:
+        example: Abuse
+        type: string
+      report_user_id:
+        example: 5
+        type: integer
+      reported_user_id:
+        example: 8
+        type: integer
     type: object
-  models.Review:
+  models.ReviewDoc:
+    properties:
+      class_id:
+        example: 9
+        type: integer
+      comment:
+        example: This class was very informative and well-structured.
+        type: string
+      id:
+        example: 101
+        type: integer
+      learner_id:
+        example: 42
+        type: integer
+      rating:
+        example: 5
+        type: integer
     type: object
-  models.Teacher:
+  models.TeacherDoc:
+    properties:
+      description:
+        example: Experienced Mathematics teacher specializing in calculus and linear
+          algebra.
+        type: string
+      id:
+        example: 12
+        type: integer
     type: object
-  models.User:
+  models.UserDoc:
+    properties:
+      admin_id:
+        example: 3
+        type: integer
+      balance:
+        example: 250.75
+        type: number
+      first_name:
+        example: Alice
+        type: string
+      gender:
+        example: Female
+        type: string
+      id:
+        example: 101
+        type: integer
+      last_name:
+        example: Smith
+        type: string
+      learner_id:
+        example: 42
+        type: integer
+      phone_number:
+        example: "+66912345678"
+        type: string
+      profile_picture:
+        example: <base64-encoded-image>
+        type: string
+      session_id:
+        example: sess-abc123xyz
+        type: string
+      teacher_id:
+        example: 7
+        type: integer
     type: object
 host: localhost:8000
 info:
@@ -50,14 +251,14 @@ paths:
         name: admin
         required: true
         schema:
-          $ref: '#/definitions/models.Admin'
+          $ref: '#/definitions/models.AdminDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Admin'
+            $ref: '#/definitions/models.AdminDoc'
         "400":
           description: Bad request
           schema:
@@ -114,7 +315,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Admin'
+            $ref: '#/definitions/models.AdminDoc'
         "400":
           description: Bad request - Invalid ID or admin not found
           schema:
@@ -135,7 +336,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Admin'
+              $ref: '#/definitions/models.AdminDoc'
             type: array
         "404":
           description: Admins not found
@@ -156,14 +357,14 @@ paths:
         name: banlearner
         required: true
         schema:
-          $ref: '#/definitions/models.BanDetailsLearner'
+          $ref: '#/definitions/models.BanDetailsLearnerDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.BanDetailsLearner'
+            $ref: '#/definitions/models.BanDetailsLearnerDoc'
         "400":
           description: Bad Request
           schema:
@@ -230,7 +431,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.BanDetailsLearner'
+            $ref: '#/definitions/models.BanDetailsLearnerDoc'
         "400":
           description: Bad Request
           schema:
@@ -267,14 +468,14 @@ paths:
         name: banlearner
         required: true
         schema:
-          $ref: '#/definitions/models.BanDetailsLearner'
+          $ref: '#/definitions/models.BanDetailsLearnerDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.BanDetailsLearner'
+            $ref: '#/definitions/models.BanDetailsLearnerDoc'
         "400":
           description: Bad Request
           schema:
@@ -306,7 +507,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.BanDetailsLearner'
+              $ref: '#/definitions/models.BanDetailsLearnerDoc'
             type: array
         "500":
           description: Internal Server Error
@@ -328,14 +529,14 @@ paths:
         name: banteacher
         required: true
         schema:
-          $ref: '#/definitions/models.BanDetailsTeacher'
+          $ref: '#/definitions/models.BanDetailsTeacherDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.BanDetailsTeacher'
+            $ref: '#/definitions/models.BanDetailsTeacherDoc'
         "400":
           description: Invalid input
           schema:
@@ -402,7 +603,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.BanDetailsTeacher'
+            $ref: '#/definitions/models.BanDetailsTeacherDoc'
         "400":
           description: Invalid ID
           schema:
@@ -439,14 +640,14 @@ paths:
         name: banteacher
         required: true
         schema:
-          $ref: '#/definitions/models.BanDetailsTeacher'
+          $ref: '#/definitions/models.BanDetailsTeacherDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.BanDetailsTeacher'
+            $ref: '#/definitions/models.BanDetailsTeacherDoc'
         "400":
           description: Invalid input or not found
           schema:
@@ -479,7 +680,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.BanDetailsTeacher'
+              $ref: '#/definitions/models.BanDetailsTeacherDoc'
             type: array
         "500":
           description: Server error
@@ -501,14 +702,14 @@ paths:
         name: class
         required: true
         schema:
-          $ref: '#/definitions/models.Class'
+          $ref: '#/definitions/models.ClassDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Class'
+            $ref: '#/definitions/models.ClassDoc'
         "400":
           description: Invalid input
           schema:
@@ -576,7 +777,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Class'
+            $ref: '#/definitions/models.ClassDoc'
         "400":
           description: Invalid ID
           schema:
@@ -613,14 +814,14 @@ paths:
         name: class
         required: true
         schema:
-          $ref: '#/definitions/models.Class'
+          $ref: '#/definitions/models.ClassDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Class'
+            $ref: '#/definitions/models.ClassDoc'
         "400":
           description: Invalid input
           schema:
@@ -653,7 +854,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.ClassCategory'
+              $ref: '#/definitions/models.ClassCategoryDoc'
             type: array
         "500":
           description: Server error
@@ -675,14 +876,14 @@ paths:
         name: class_category
         required: true
         schema:
-          $ref: '#/definitions/models.ClassCategory'
+          $ref: '#/definitions/models.ClassCategoryDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.ClassCategory'
+            $ref: '#/definitions/models.ClassCategoryDoc'
         "400":
           description: Invalid input
           schema:
@@ -750,7 +951,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ClassCategory'
+            $ref: '#/definitions/models.ClassCategoryDoc'
         "400":
           description: Invalid ID
           schema:
@@ -787,14 +988,14 @@ paths:
         name: class_category
         required: true
         schema:
-          $ref: '#/definitions/models.ClassCategory'
+          $ref: '#/definitions/models.ClassCategoryDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ClassCategory'
+            $ref: '#/definitions/models.ClassCategoryDoc'
         "400":
           description: Invalid input
           schema:
@@ -827,14 +1028,14 @@ paths:
         name: class_session
         required: true
         schema:
-          $ref: '#/definitions/models.ClassSession'
+          $ref: '#/definitions/models.ClassSessionDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.ClassSession'
+            $ref: '#/definitions/models.ClassSessionDoc'
         "400":
           description: Invalid input
           schema:
@@ -902,7 +1103,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ClassSession'
+            $ref: '#/definitions/models.ClassSessionDoc'
         "400":
           description: Invalid ID
           schema:
@@ -939,14 +1140,14 @@ paths:
         name: class_session
         required: true
         schema:
-          $ref: '#/definitions/models.ClassSession'
+          $ref: '#/definitions/models.ClassSessionDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ClassSession'
+            $ref: '#/definitions/models.ClassSessionDoc'
         "400":
           description: Invalid input
           schema:
@@ -979,7 +1180,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.ClassSession'
+              $ref: '#/definitions/models.ClassSessionDoc'
             type: array
         "500":
           description: Server error
@@ -1001,7 +1202,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Class'
+              $ref: '#/definitions/models.ClassDoc'
             type: array
         "500":
           description: Server error
@@ -1023,14 +1224,14 @@ paths:
         name: enrollment
         required: true
         schema:
-          $ref: '#/definitions/models.Enrollment'
+          $ref: '#/definitions/models.EnrollmentDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Enrollment'
+            $ref: '#/definitions/models.EnrollmentDoc'
         "400":
           description: Invalid input
           schema:
@@ -1098,7 +1299,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Enrollment'
+            $ref: '#/definitions/models.EnrollmentDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1135,14 +1336,14 @@ paths:
         name: enrollment
         required: true
         schema:
-          $ref: '#/definitions/models.Enrollment'
+          $ref: '#/definitions/models.EnrollmentDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Enrollment'
+            $ref: '#/definitions/models.EnrollmentDoc'
         "400":
           description: Invalid input
           schema:
@@ -1175,7 +1376,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Enrollment'
+              $ref: '#/definitions/models.EnrollmentDoc'
             type: array
         "500":
           description: Server error
@@ -1197,14 +1398,14 @@ paths:
         name: learner
         required: true
         schema:
-          $ref: '#/definitions/models.Learner'
+          $ref: '#/definitions/models.LearnerDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Learner'
+            $ref: '#/definitions/models.LearnerDoc'
         "400":
           description: Invalid input
           schema:
@@ -1271,7 +1472,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Learner'
+            $ref: '#/definitions/models.LearnerDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1303,7 +1504,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Learner'
+              $ref: '#/definitions/models.LearnerDoc'
             type: array
         "500":
           description: Server error
@@ -1325,14 +1526,14 @@ paths:
         name: notification
         required: true
         schema:
-          $ref: '#/definitions/models.Notification'
+          $ref: '#/definitions/models.NotificationDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Notification'
+            $ref: '#/definitions/models.NotificationDoc'
         "400":
           description: Invalid input
           schema:
@@ -1400,7 +1601,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Notification'
+            $ref: '#/definitions/models.NotificationDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1437,14 +1638,14 @@ paths:
         name: notification
         required: true
         schema:
-          $ref: '#/definitions/models.Notification'
+          $ref: '#/definitions/models.NotificationDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Notification'
+            $ref: '#/definitions/models.NotificationDoc'
         "400":
           description: Invalid input
           schema:
@@ -1477,7 +1678,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Notification'
+              $ref: '#/definitions/models.NotificationDoc'
             type: array
         "500":
           description: Server error
@@ -1499,14 +1700,14 @@ paths:
         name: report
         required: true
         schema:
-          $ref: '#/definitions/models.Report'
+          $ref: '#/definitions/models.ReportDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Report'
+            $ref: '#/definitions/models.ReportDoc'
         "400":
           description: Invalid input
           schema:
@@ -1574,7 +1775,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Report'
+            $ref: '#/definitions/models.ReportDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1611,14 +1812,14 @@ paths:
         name: report
         required: true
         schema:
-          $ref: '#/definitions/models.Report'
+          $ref: '#/definitions/models.ReportDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Report'
+            $ref: '#/definitions/models.ReportDoc'
         "400":
           description: Invalid input
           schema:
@@ -1651,7 +1852,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Report'
+              $ref: '#/definitions/models.ReportDoc'
             type: array
         "500":
           description: Server error
@@ -1673,14 +1874,14 @@ paths:
         name: review
         required: true
         schema:
-          $ref: '#/definitions/models.Review'
+          $ref: '#/definitions/models.ReviewDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Review'
+            $ref: '#/definitions/models.ReviewDoc'
         "400":
           description: Invalid input or rating out of range
           schema:
@@ -1748,7 +1949,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Review'
+            $ref: '#/definitions/models.ReviewDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1786,14 +1987,14 @@ paths:
         name: review
         required: true
         schema:
-          $ref: '#/definitions/models.Review'
+          $ref: '#/definitions/models.ReviewDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Review'
+            $ref: '#/definitions/models.ReviewDoc'
         "400":
           description: Invalid input or rating out of range
           schema:
@@ -1826,7 +2027,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Review'
+              $ref: '#/definitions/models.ReviewDoc'
             type: array
         "500":
           description: Server error
@@ -1848,14 +2049,14 @@ paths:
         name: teacher
         required: true
         schema:
-          $ref: '#/definitions/models.Teacher'
+          $ref: '#/definitions/models.TeacherDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.Teacher'
+            $ref: '#/definitions/models.TeacherDoc'
         "400":
           description: Invalid input
           schema:
@@ -1922,7 +2123,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Teacher'
+            $ref: '#/definitions/models.TeacherDoc'
         "400":
           description: Invalid ID
           schema:
@@ -1959,14 +2160,14 @@ paths:
         name: teacher
         required: true
         schema:
-          $ref: '#/definitions/models.Teacher'
+          $ref: '#/definitions/models.TeacherDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Teacher'
+            $ref: '#/definitions/models.TeacherDoc'
         "400":
           description: Invalid input
           schema:
@@ -1998,7 +2199,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Teacher'
+              $ref: '#/definitions/models.TeacherDoc'
             type: array
         "500":
           description: Server error
@@ -2020,14 +2221,14 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/models.User'
+          $ref: '#/definitions/models.UserDoc'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/models.User'
+            $ref: '#/definitions/models.UserDoc'
         "400":
           description: Invalid input
           schema:
@@ -2094,7 +2295,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.User'
+            $ref: '#/definitions/models.UserDoc'
         "400":
           description: Invalid ID
           schema:
@@ -2131,14 +2332,14 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/models.User'
+          $ref: '#/definitions/models.UserDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.User'
+            $ref: '#/definitions/models.UserDoc'
         "400":
           description: Invalid input
           schema:
@@ -2170,7 +2371,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.User'
+              $ref: '#/definitions/models.UserDoc'
             type: array
         "500":
           description: Server error

--- a/handlers/admin_handler.go
+++ b/handlers/admin_handler.go
@@ -22,8 +22,8 @@ func AdminRoutes(app *fiber.App) {
 // @Tags admins
 // @Accept json
 // @Produce json
-// @Param admin body models.Admin true "Admin data"
-// @Success 200 {object} models.Admin
+// @Param admin body models.AdminDoc true "Admin data"
+// @Success 200 {object} models.AdminDoc
 // @Failure 400 {object} map[string]interface{} "Bad request"
 // @Router /admin [post]
 func CreateAdmin(c *fiber.Ctx) error {
@@ -45,7 +45,7 @@ func CreateAdmin(c *fiber.Ctx) error {
 // @Tags admins
 // @Accept json
 // @Produce json
-// @Success 200 {array} models.Admin
+// @Success 200 {array} models.AdminDoc
 // @Failure 404 {object} map[string]interface{} "Admins not found"
 // @Router /admins [get]
 func GetAdmins(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findAdmin(id int, admin *models.Admin) error {
 // @Accept json
 // @Produce json
 // @Param id path int true "Admin ID"
-// @Success 200 {object} models.Admin
+// @Success 200 {object} models.AdminDoc
 // @Failure 400 {object} map[string]interface{} "Bad request - Invalid ID or admin not found"
 // @Router /admin/{id} [get]
 func GetAdmin(c *fiber.Ctx) error {

--- a/handlers/ban_learner_handler.go
+++ b/handlers/ban_learner_handler.go
@@ -22,8 +22,8 @@ func BanLearnerRoutes(app *fiber.App) {
 // @Tags         BanLearners
 // @Accept       json
 // @Produce      json
-// @Param        banlearner  body      models.BanDetailsLearner  true  "Ban Learner Payload"
-// @Success      201         {object}  models.BanDetailsLearner
+// @Param        banlearner  body      models.BanDetailsLearnerDoc  true  "Ban Learner Payload"
+// @Success      201         {object}  models.BanDetailsLearnerDoc
 // @Failure      400         {object}  map[string]string
 // @Failure      500         {object}  map[string]string
 // @Router       /banlearner [post]
@@ -45,7 +45,7 @@ func CreateBanLearner(c *fiber.Ctx) error {
 // @Description  GetBanLearners returns a list of all ban records
 // @Tags         BanLearners
 // @Produce      json
-// @Success      200  {array}   models.BanDetailsLearner
+// @Success      200  {array}   models.BanDetailsLearnerDoc
 // @Failure      500  {object}  map[string]string
 // @Router       /banlearners [get]
 func GetBanLearners(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findBanLearner(id int, banlearner *models.BanDetailsLearner) error {
 // @Tags         BanLearners
 // @Produce      json
 // @Param        id   path      int  true  "Ban Learner ID"
-// @Success      200  {object}  models.BanDetailsLearner
+// @Success      200  {object}  models.BanDetailsLearnerDoc
 // @Failure      400  {object}  map[string]string
 // @Failure      404  {object}  map[string]string
 // @Failure      500  {object}  map[string]string
@@ -99,8 +99,8 @@ func GetBanLearner(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id           path      int                     true  "Ban Learner ID"
-// @Param        banlearner   body      models.BanDetailsLearner  true  "Updated ban record"
-// @Success      200          {object}  models.BanDetailsLearner
+// @Param        banlearner   body      models.BanDetailsLearnerDoc  true  "Updated ban record"
+// @Success      200          {object}  models.BanDetailsLearnerDoc
 // @Failure      400          {object}  map[string]string
 // @Failure      404          {object}  map[string]string
 // @Failure      500          {object}  map[string]string

--- a/handlers/ban_learner_handler.go
+++ b/handlers/ban_learner_handler.go
@@ -16,6 +16,17 @@ func BanLearnerRoutes(app *fiber.App) {
 	app.Delete("/banlearner/:id", DeleteBanLearner)
 }
 
+// CreateBanLearner godoc
+// @Summary      Create a new banned learner record
+// @Description  CreateBanLearner creates a new ban record for a learner
+// @Tags         BanLearners
+// @Accept       json
+// @Produce      json
+// @Param        banlearner  body      models.BanDetailsLearner  true  "Ban Learner Payload"
+// @Success      201         {object}  models.BanDetailsLearner
+// @Failure      400         {object}  map[string]string
+// @Failure      500         {object}  map[string]string
+// @Router       /banlearner [post]
 func CreateBanLearner(c *fiber.Ctx) error {
 	var banlearner models.BanDetailsLearner
 
@@ -29,6 +40,14 @@ func CreateBanLearner(c *fiber.Ctx) error {
 	return c.Status(201).JSON(banlearner)
 }
 
+// GetBanLearners godoc
+// @Summary      Get all banned learners
+// @Description  GetBanLearners returns a list of all ban records
+// @Tags         BanLearners
+// @Produce      json
+// @Success      200  {array}   models.BanDetailsLearner
+// @Failure      500  {object}  map[string]string
+// @Router       /banlearners [get]
 func GetBanLearners(c *fiber.Ctx) error {
 	banlearners := []models.BanDetailsLearner{}
 	if err := db.Preload("Learner").Find(&banlearners).Error; err != nil {
@@ -42,6 +61,17 @@ func findBanLearner(id int, banlearner *models.BanDetailsLearner) error {
 	return db.Preload("Learner").First(banlearner, "id = ?", id).Error
 }
 
+// GetBanLearner godoc
+// @Summary      Get a banned learner by ID
+// @Description  GetBanLearner returns a single ban record by ID
+// @Tags         BanLearners
+// @Produce      json
+// @Param        id   path      int  true  "Ban Learner ID"
+// @Success      200  {object}  models.BanDetailsLearner
+// @Failure      400  {object}  map[string]string
+// @Failure      404  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Router       /banlearner/{id} [get]
 func GetBanLearner(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetBanLearner(c *fiber.Ctx) error {
 	return c.Status(200).JSON(banlearner)
 }
 
+// UpdateBanLearner godoc
+// @Summary      Update a banned learner record
+// @Description  UpdateBanLearner modifies an existing ban record
+// @Tags         BanLearners
+// @Accept       json
+// @Produce      json
+// @Param        id           path      int                     true  "Ban Learner ID"
+// @Param        banlearner   body      models.BanDetailsLearner  true  "Updated ban record"
+// @Success      200          {object}  models.BanDetailsLearner
+// @Failure      400          {object}  map[string]string
+// @Failure      404          {object}  map[string]string
+// @Failure      500          {object}  map[string]string
+// @Router       /banlearner/{id} [put]
 func UpdateBanLearner(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -92,6 +135,17 @@ func UpdateBanLearner(c *fiber.Ctx) error {
 
 }
 
+// DeleteBanLearner godoc
+// @Summary      Delete a banned learner record
+// @Description  DeleteBanLearner deletes a ban record by ID
+// @Tags         BanLearners
+// @Produce      json
+// @Param        id   path      int  true  "Ban Learner ID"
+// @Success      200  {string}  string  "Successfully deleted ban learner"
+// @Failure      400  {object}  map[string]string
+// @Failure      404  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Router       /banlearner/{id} [delete]
 func DeleteBanLearner(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/ban_teacher_handler.go
+++ b/handlers/ban_teacher_handler.go
@@ -16,6 +16,17 @@ func BanTeacherRoutes(app *fiber.App) {
 	app.Delete("/banteacher/:id", DeleteBanTeacher)
 }
 
+// CreateBanTeacher godoc
+// @Summary      Create a new ban record for a teacher
+// @Description  CreateBanTeacher creates a new BanDetailsTeacher entry
+// @Tags         BanTeachers
+// @Accept       json
+// @Produce      json
+// @Param        banteacher  body      models.BanDetailsTeacher  true  "BanTeacher payload"
+// @Success      201         {object}  models.BanDetailsTeacher
+// @Failure      400         {object}  map[string]string         "Invalid input"
+// @Failure      500         {object}  map[string]string         "Server error"
+// @Router       /banteacher [post]
 func CreateBanTeacher(c *fiber.Ctx) error {
 	var banteacher models.BanDetailsTeacher
 
@@ -29,6 +40,14 @@ func CreateBanTeacher(c *fiber.Ctx) error {
 	return c.Status(201).JSON(banteacher)
 }
 
+// GetBanTeachers godoc
+// @Summary      List all ban records for teachers
+// @Description  GetBanTeachers retrieves all BanDetailsTeacher entries with associated Teacher
+// @Tags         BanTeachers
+// @Produce      json
+// @Success      200  {array}   models.BanDetailsTeacher
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /banteachers [get]
 func GetBanTeachers(c *fiber.Ctx) error {
 	banteachers := []models.BanDetailsTeacher{}
 	if err := db.Preload("Teacher").Find(&banteachers).Error; err != nil {
@@ -42,6 +61,17 @@ func findBanTeacher(id int, banteacher *models.BanDetailsTeacher) error {
 	return db.Preload("Teacher").First(banteacher, "id = ?", id).Error
 }
 
+// GetBanTeacher godoc
+// @Summary      Get ban record by ID
+// @Description  GetBanTeacher retrieves a single BanDetailsTeacher by its ID
+// @Tags         BanTeachers
+// @Produce      json
+// @Param        id   path      int  true  "BanTeacher ID"
+// @Success      200  {object}  models.BanDetailsTeacher
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "BanTeacher not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /banteacher/{id} [get]
 func GetBanTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetBanTeacher(c *fiber.Ctx) error {
 	return c.Status(200).JSON(banteacher)
 }
 
+// UpdateBanTeacher godoc
+// @Summary      Update a ban record by ID
+// @Description  UpdateBanTeacher updates an existing BanDetailsTeacher
+// @Tags         BanTeachers
+// @Accept       json
+// @Produce      json
+// @Param        id           path      int                     true  "BanTeacher ID"
+// @Param        banteacher   body      models.BanDetailsTeacher  true  "Updated payload"
+// @Success      200          {object}  models.BanDetailsTeacher
+// @Failure      400          {object}  map[string]string         "Invalid input or not found"
+// @Failure      404          {object}  map[string]string         "BanTeacher not found"
+// @Failure      500          {object}  map[string]string         "Server error"
+// @Router       /banteacher/{id} [put]
 func UpdateBanTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -91,6 +134,17 @@ func UpdateBanTeacher(c *fiber.Ctx) error {
 	return c.Status(200).JSON(banteacher)
 }
 
+// DeleteBanTeacher godoc
+// @Summary      Delete a ban record by ID
+// @Description  DeleteBanTeacher removes a BanDetailsTeacher record by its ID
+// @Tags         BanTeachers
+// @Produce      json
+// @Param        id   path      int  true  "BanTeacher ID"
+// @Success      200  {string}  string  "Successfully deleted ban teacher"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "BanTeacher not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /banteacher/{id} [delete]
 func DeleteBanTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/ban_teacher_handler.go
+++ b/handlers/ban_teacher_handler.go
@@ -22,8 +22,8 @@ func BanTeacherRoutes(app *fiber.App) {
 // @Tags         BanTeachers
 // @Accept       json
 // @Produce      json
-// @Param        banteacher  body      models.BanDetailsTeacher  true  "BanTeacher payload"
-// @Success      201         {object}  models.BanDetailsTeacher
+// @Param        banteacher  body      models.BanDetailsTeacherDoc  true  "BanTeacher payload"
+// @Success      201         {object}  models.BanDetailsTeacherDoc
 // @Failure      400         {object}  map[string]string         "Invalid input"
 // @Failure      500         {object}  map[string]string         "Server error"
 // @Router       /banteacher [post]
@@ -45,7 +45,7 @@ func CreateBanTeacher(c *fiber.Ctx) error {
 // @Description  GetBanTeachers retrieves all BanDetailsTeacher entries with associated Teacher
 // @Tags         BanTeachers
 // @Produce      json
-// @Success      200  {array}   models.BanDetailsTeacher
+// @Success      200  {array}   models.BanDetailsTeacherDoc
 // @Failure      500  {object}  map[string]string  "Server error"
 // @Router       /banteachers [get]
 func GetBanTeachers(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findBanTeacher(id int, banteacher *models.BanDetailsTeacher) error {
 // @Tags         BanTeachers
 // @Produce      json
 // @Param        id   path      int  true  "BanTeacher ID"
-// @Success      200  {object}  models.BanDetailsTeacher
+// @Success      200  {object}  models.BanDetailsTeacherDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "BanTeacher not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -99,8 +99,8 @@ func GetBanTeacher(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id           path      int                     true  "BanTeacher ID"
-// @Param        banteacher   body      models.BanDetailsTeacher  true  "Updated payload"
-// @Success      200          {object}  models.BanDetailsTeacher
+// @Param        banteacher   body      models.BanDetailsTeacherDoc  true  "Updated payload"
+// @Success      200          {object}  models.BanDetailsTeacherDoc
 // @Failure      400          {object}  map[string]string         "Invalid input or not found"
 // @Failure      404          {object}  map[string]string         "BanTeacher not found"
 // @Failure      500          {object}  map[string]string         "Server error"

--- a/handlers/class_category_handler.go
+++ b/handlers/class_category_handler.go
@@ -22,8 +22,8 @@ func ClassCategoryRoutes(app *fiber.App) {
 // @Tags         ClassCategories
 // @Accept       json
 // @Produce      json
-// @Param        class_category  body      models.ClassCategory  true  "ClassCategory payload"
-// @Success      201             {object}  models.ClassCategory
+// @Param        class_category  body      models.ClassCategoryDoc  true  "ClassCategory payload"
+// @Success      201             {object}  models.ClassCategoryDoc
 // @Failure      400             {object}  map[string]string    "Invalid input"
 // @Failure      500             {object}  map[string]string    "Server error"
 // @Router       /class_category [post]
@@ -46,7 +46,7 @@ func CreateClassCategory(c *fiber.Ctx) error {
 // @Description  GetClassCategories retrieves all ClassCategory records with Classes relation
 // @Tags         ClassCategories
 // @Produce      json
-// @Success      200             {array}   models.ClassCategory
+// @Success      200             {array}   models.ClassCategoryDoc
 // @Failure      500             {object}  map[string]string    "Server error"
 // @Router       /class_categories [get]
 func GetClassCategories(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findClassCategory(id int, class_category *models.ClassCategory) error {
 // @Tags         ClassCategories
 // @Produce      json
 // @Param        id   path      int                true  "ClassCategory ID"
-// @Success      200  {object}  models.ClassCategory
+// @Success      200  {object}  models.ClassCategoryDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "ClassCategory not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -100,8 +100,8 @@ func GetClassCategory(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id              path      int                   true  "ClassCategory ID"
-// @Param        class_category  body      models.ClassCategory  true  "Updated payload"
-// @Success      200             {object}  models.ClassCategory
+// @Param        class_category  body      models.ClassCategoryDoc  true  "Updated payload"
+// @Success      200             {object}  models.ClassCategoryDoc
 // @Failure      400             {object}  map[string]string    "Invalid input"
 // @Failure      404             {object}  map[string]string    "ClassCategory not found"
 // @Failure      500             {object}  map[string]string    "Server error"

--- a/handlers/class_category_handler.go
+++ b/handlers/class_category_handler.go
@@ -16,6 +16,17 @@ func ClassCategoryRoutes(app *fiber.App) {
 	app.Delete("/class_category/:id", DeleteClassCategory)
 }
 
+// CreateClassCategory godoc
+// @Summary      Create a new class category
+// @Description  CreateClassCategory creates a new ClassCategory record
+// @Tags         ClassCategories
+// @Accept       json
+// @Produce      json
+// @Param        class_category  body      models.ClassCategory  true  "ClassCategory payload"
+// @Success      201             {object}  models.ClassCategory
+// @Failure      400             {object}  map[string]string    "Invalid input"
+// @Failure      500             {object}  map[string]string    "Server error"
+// @Router       /class_category [post]
 func CreateClassCategory(c *fiber.Ctx) error {
 	var class_category models.ClassCategory
 
@@ -30,6 +41,14 @@ func CreateClassCategory(c *fiber.Ctx) error {
 	return c.Status(201).JSON(class_category)
 }
 
+// GetClassCategories godoc
+// @Summary      List all class categories
+// @Description  GetClassCategories retrieves all ClassCategory records with Classes relation
+// @Tags         ClassCategories
+// @Produce      json
+// @Success      200             {array}   models.ClassCategory
+// @Failure      500             {object}  map[string]string    "Server error"
+// @Router       /class_categories [get]
 func GetClassCategories(c *fiber.Ctx) error {
 	class_categories := []models.ClassCategory{}
 	if err := db.Preload("Classes").Find(&class_categories).Error; err != nil {
@@ -43,6 +62,17 @@ func findClassCategory(id int, class_category *models.ClassCategory) error {
 	return db.Preload("Classes").First(class_category, "id = ?", id).Error
 }
 
+// GetClassCategory godoc
+// @Summary      Get class category by ID
+// @Description  GetClassCategory retrieves a single ClassCategory by its ID, including Classes
+// @Tags         ClassCategories
+// @Produce      json
+// @Param        id   path      int                true  "ClassCategory ID"
+// @Success      200  {object}  models.ClassCategory
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "ClassCategory not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /class_category/{id} [get]
 func GetClassCategory(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -63,6 +93,19 @@ func GetClassCategory(c *fiber.Ctx) error {
 	return c.Status(200).JSON(class_category)
 }
 
+// UpdateClassCategory godoc
+// @Summary      Update an existing class category
+// @Description  UpdateClassCategory updates a ClassCategory record by its ID
+// @Tags         ClassCategories
+// @Accept       json
+// @Produce      json
+// @Param        id              path      int                   true  "ClassCategory ID"
+// @Param        class_category  body      models.ClassCategory  true  "Updated payload"
+// @Success      200             {object}  models.ClassCategory
+// @Failure      400             {object}  map[string]string    "Invalid input"
+// @Failure      404             {object}  map[string]string    "ClassCategory not found"
+// @Failure      500             {object}  map[string]string    "Server error"
+// @Router       /class_category/{id} [put]
 func UpdateClassCategory(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -93,6 +136,17 @@ func UpdateClassCategory(c *fiber.Ctx) error {
 
 }
 
+// DeleteClassCategory godoc
+// @Summary      Delete a class category by ID
+// @Description  DeleteClassCategory removes a ClassCategory record by its ID
+// @Tags         ClassCategories
+// @Produce      json
+// @Param        id   path      int                true  "ClassCategory ID"
+// @Success      200  {string}  string  "Successfully deleted class category"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "ClassCategory not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /class_category/{id} [delete]
 func DeleteClassCategory(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/class_handler.go
+++ b/handlers/class_handler.go
@@ -16,6 +16,17 @@ func ClassRoutes(app *fiber.App) {
 	app.Delete("/class/:id", DeleteClass)
 }
 
+// CreateClass godoc
+// @Summary      Create a new class
+// @Description  CreateClass creates a new Class record
+// @Tags         Classes
+// @Accept       json
+// @Produce      json
+// @Param        class  body      models.Class  true  "Class payload"
+// @Success      201    {object}  models.Class
+// @Failure      400    {object}  map[string]string  "Invalid input"
+// @Failure      500    {object}  map[string]string  "Server error"
+// @Router       /class [post]
 func CreateClass(c *fiber.Ctx) error {
 	var class models.Class
 
@@ -29,6 +40,14 @@ func CreateClass(c *fiber.Ctx) error {
 	return c.Status(201).JSON(class)
 }
 
+// GetClasses godoc
+// @Summary      List all classes
+// @Description  GetClasses retrieves all Class records with Teacher and Categories relations
+// @Tags         Classes
+// @Produce      json
+// @Success      200    {array}   models.Class
+// @Failure      500    {object}  map[string]string  "Server error"
+// @Router       /classes [get]
 func GetClasses(c *fiber.Ctx) error {
 	classes := []models.Class{}
 	if err := db.Preload("Teacher").Preload("Categories").Find(&classes).Error; err != nil {
@@ -42,6 +61,17 @@ func findClass(id int, class *models.Class) error {
 	return db.Preload("Teacher").Preload("Categories").First(class, "id = ?", id).Error
 }
 
+// GetClass godoc
+// @Summary      Get class by ID
+// @Description  GetClass retrieves a single Class by its ID, including Teacher and Categories
+// @Tags         Classes
+// @Produce      json
+// @Param        id    path      int  true  "Class ID"
+// @Success      200   {object}  models.Class
+// @Failure      400   {object}  map[string]string  "Invalid ID"
+// @Failure      404   {object}  map[string]string  "Class not found"
+// @Failure      500   {object}  map[string]string  "Server error"
+// @Router       /class/{id} [get]
 func GetClass(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetClass(c *fiber.Ctx) error {
 	return c.Status(200).JSON(class)
 }
 
+// UpdateClass godoc
+// @Summary      Update an existing class
+// @Description  UpdateClass updates a Class record by its ID
+// @Tags         Classes
+// @Accept       json
+// @Produce      json
+// @Param        id     path      int           true  "Class ID"
+// @Param        class  body      models.Class  true  "Updated class payload"
+// @Success      200    {object}  models.Class
+// @Failure      400    {object}  map[string]string  "Invalid input"
+// @Failure      404    {object}  map[string]string  "Class not found"
+// @Failure      500    {object}  map[string]string  "Server error"
+// @Router       /class/{id} [put]
 func UpdateClass(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -92,6 +135,17 @@ func UpdateClass(c *fiber.Ctx) error {
 
 }
 
+// DeleteClass godoc
+// @Summary      Delete a class by ID
+// @Description  DeleteClass removes a Class record by its ID
+// @Tags         Classes
+// @Produce      json
+// @Param        id   path      int  true  "Class ID"
+// @Success      200  {string}  string  "Successfully deleted class"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Class not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /class/{id} [delete]
 func DeleteClass(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/class_handler.go
+++ b/handlers/class_handler.go
@@ -22,8 +22,8 @@ func ClassRoutes(app *fiber.App) {
 // @Tags         Classes
 // @Accept       json
 // @Produce      json
-// @Param        class  body      models.Class  true  "Class payload"
-// @Success      201    {object}  models.Class
+// @Param        class  body      models.ClassDoc  true  "Class payload"
+// @Success      201    {object}  models.ClassDoc
 // @Failure      400    {object}  map[string]string  "Invalid input"
 // @Failure      500    {object}  map[string]string  "Server error"
 // @Router       /class [post]
@@ -45,7 +45,7 @@ func CreateClass(c *fiber.Ctx) error {
 // @Description  GetClasses retrieves all Class records with Teacher and Categories relations
 // @Tags         Classes
 // @Produce      json
-// @Success      200    {array}   models.Class
+// @Success      200    {array}   models.ClassDoc
 // @Failure      500    {object}  map[string]string  "Server error"
 // @Router       /classes [get]
 func GetClasses(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findClass(id int, class *models.Class) error {
 // @Tags         Classes
 // @Produce      json
 // @Param        id    path      int  true  "Class ID"
-// @Success      200   {object}  models.Class
+// @Success      200   {object}  models.ClassDoc
 // @Failure      400   {object}  map[string]string  "Invalid ID"
 // @Failure      404   {object}  map[string]string  "Class not found"
 // @Failure      500   {object}  map[string]string  "Server error"
@@ -99,8 +99,8 @@ func GetClass(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id     path      int           true  "Class ID"
-// @Param        class  body      models.Class  true  "Updated class payload"
-// @Success      200    {object}  models.Class
+// @Param        class  body      models.ClassDoc  true  "Updated class payload"
+// @Success      200    {object}  models.ClassDoc
 // @Failure      400    {object}  map[string]string  "Invalid input"
 // @Failure      404    {object}  map[string]string  "Class not found"
 // @Failure      500    {object}  map[string]string  "Server error"

--- a/handlers/class_session_handler.go
+++ b/handlers/class_session_handler.go
@@ -22,8 +22,8 @@ func ClassSessionRoutes(app *fiber.App) {
 // @Tags         ClassSessions
 // @Accept       json
 // @Produce      json
-// @Param        class_session  body      models.ClassSession  true  "ClassSession payload"
-// @Success      201            {object}  models.ClassSession
+// @Param        class_session  body      models.ClassSessionDoc  true  "ClassSession payload"
+// @Success      201            {object}  models.ClassSessionDoc
 // @Failure      400            {object}  map[string]string    "Invalid input"
 // @Failure      500            {object}  map[string]string    "Server error"
 // @Router       /class_session [post]
@@ -46,7 +46,7 @@ func CreateClassSession(c *fiber.Ctx) error {
 // @Description  GetClassSessions retrieves all ClassSession records with Class relation
 // @Tags         ClassSessions
 // @Produce      json
-// @Success      200            {array}   models.ClassSession
+// @Success      200            {array}   models.ClassSessionDoc
 // @Failure      500            {object}  map[string]string    "Server error"
 // @Router       /class_sessions [get]
 func GetClassSessions(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findClassSession(id int, class_session *models.ClassSession) error {
 // @Tags         ClassSessions
 // @Produce      json
 // @Param        id   path      int                true  "ClassSession ID"
-// @Success      200  {object}  models.ClassSession
+// @Success      200  {object}  models.ClassSessionDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "ClassSession not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -100,8 +100,8 @@ func GetClassSession(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id             path      int                  true  "ClassSession ID"
-// @Param        class_session  body      models.ClassSession  true  "Updated ClassSession payload"
-// @Success      200            {object}  models.ClassSession
+// @Param        class_session  body      models.ClassSessionDoc  true  "Updated ClassSession payload"
+// @Success      200            {object}  models.ClassSessionDoc
 // @Failure      400            {object}  map[string]string    "Invalid input"
 // @Failure      404            {object}  map[string]string    "ClassSession not found"
 // @Failure      500            {object}  map[string]string    "Server error"

--- a/handlers/class_session_handler.go
+++ b/handlers/class_session_handler.go
@@ -16,6 +16,17 @@ func ClassSessionRoutes(app *fiber.App) {
 	app.Delete("/class_session/:id", DeleteClassSession)
 }
 
+// CreateClassSession godoc
+// @Summary      Create a new class session
+// @Description  CreateClassSession creates a new ClassSession record
+// @Tags         ClassSessions
+// @Accept       json
+// @Produce      json
+// @Param        class_session  body      models.ClassSession  true  "ClassSession payload"
+// @Success      201            {object}  models.ClassSession
+// @Failure      400            {object}  map[string]string    "Invalid input"
+// @Failure      500            {object}  map[string]string    "Server error"
+// @Router       /class_session [post]
 func CreateClassSession(c *fiber.Ctx) error {
 	var class_session models.ClassSession
 
@@ -30,6 +41,14 @@ func CreateClassSession(c *fiber.Ctx) error {
 	return c.Status(201).JSON(class_session)
 }
 
+// GetClassSessions godoc
+// @Summary      List all class sessions
+// @Description  GetClassSessions retrieves all ClassSession records with Class relation
+// @Tags         ClassSessions
+// @Produce      json
+// @Success      200            {array}   models.ClassSession
+// @Failure      500            {object}  map[string]string    "Server error"
+// @Router       /class_sessions [get]
 func GetClassSessions(c *fiber.Ctx) error {
 	class_sessions := []models.ClassSession{}
 	if err := db.Preload("Class").Find(&class_sessions).Error; err != nil {
@@ -43,6 +62,17 @@ func findClassSession(id int, class_session *models.ClassSession) error {
 	return db.Preload("Class").First(class_session, "id = ?", id).Error
 }
 
+// GetClassSession godoc
+// @Summary      Get class session by ID
+// @Description  GetClassSession retrieves a single ClassSession by its ID, including Class
+// @Tags         ClassSessions
+// @Produce      json
+// @Param        id   path      int                true  "ClassSession ID"
+// @Success      200  {object}  models.ClassSession
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "ClassSession not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /class_session/{id} [get]
 func GetClassSession(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -63,6 +93,19 @@ func GetClassSession(c *fiber.Ctx) error {
 	return c.Status(200).JSON(class_session)
 }
 
+// UpdateClassSession godoc
+// @Summary      Update an existing class session
+// @Description  UpdateClassSession updates a ClassSession record by its ID
+// @Tags         ClassSessions
+// @Accept       json
+// @Produce      json
+// @Param        id             path      int                  true  "ClassSession ID"
+// @Param        class_session  body      models.ClassSession  true  "Updated ClassSession payload"
+// @Success      200            {object}  models.ClassSession
+// @Failure      400            {object}  map[string]string    "Invalid input"
+// @Failure      404            {object}  map[string]string    "ClassSession not found"
+// @Failure      500            {object}  map[string]string    "Server error"
+// @Router       /class_session/{id} [put]
 func UpdateClassSession(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -93,6 +136,17 @@ func UpdateClassSession(c *fiber.Ctx) error {
 
 }
 
+// DeleteClassSession godoc
+// @Summary      Delete a class session by ID
+// @Description  DeleteClassSession removes a ClassSession record by its ID
+// @Tags         ClassSessions
+// @Produce      json
+// @Param        id   path      int                true  "ClassSession ID"
+// @Success      200  {string}  string  "Successfully deleted class session"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "ClassSession not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /class_session/{id} [delete]
 func DeleteClassSession(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/enrollment_handler.go
+++ b/handlers/enrollment_handler.go
@@ -22,8 +22,8 @@ func EnrollmentRoutes(app *fiber.App) {
 // @Tags         Enrollments
 // @Accept       json
 // @Produce      json
-// @Param        enrollment  body      models.Enrollment  true  "Enrollment payload"
-// @Success      201         {object}  models.Enrollment
+// @Param        enrollment  body      models.EnrollmentDoc  true  "Enrollment payload"
+// @Success      201         {object}  models.EnrollmentDoc
 // @Failure      400         {object}  map[string]string  "Invalid input"
 // @Failure      500         {object}  map[string]string  "Server error"
 // @Router       /enrollment [post]
@@ -46,7 +46,7 @@ func CreateEnrollment(c *fiber.Ctx) error {
 // @Description  GetEnrollments retrieves all Enrollment records with associated Learner and Class
 // @Tags         Enrollments
 // @Produce      json
-// @Success      200         {array}   models.Enrollment
+// @Success      200         {array}   models.EnrollmentDoc
 // @Failure      500         {object}  map[string]string  "Server error"
 // @Router       /enrollments [get]
 func GetEnrollments(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findEnrollment(id int, enrollment *models.Enrollment) error {
 // @Tags         Enrollments
 // @Produce      json
 // @Param        id   path      int  true  "Enrollment ID"
-// @Success      200  {object}  models.Enrollment
+// @Success      200  {object}  models.EnrollmentDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Enrollment not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -99,8 +99,8 @@ func GetEnrollment(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id           path      int                  true  "Enrollment ID"
-// @Param        enrollment   body      models.Enrollment    true  "Updated enrollment payload"
-// @Success      200          {object}  models.Enrollment
+// @Param        enrollment   body      models.EnrollmentDoc    true  "Updated enrollment payload"
+// @Success      200          {object}  models.EnrollmentDoc
 // @Failure      400          {object}  map[string]string  "Invalid input"
 // @Failure      404          {object}  map[string]string  "Enrollment not found"
 // @Failure      500          {object}  map[string]string  "Server error"

--- a/handlers/enrollment_handler.go
+++ b/handlers/enrollment_handler.go
@@ -16,6 +16,17 @@ func EnrollmentRoutes(app *fiber.App) {
 	app.Delete("/enrollment/:id", DeleteEnrollment)
 }
 
+// CreateEnrollment godoc
+// @Summary      Create a new enrollment
+// @Description  CreateEnrollment creates a new Enrollment record
+// @Tags         Enrollments
+// @Accept       json
+// @Produce      json
+// @Param        enrollment  body      models.Enrollment  true  "Enrollment payload"
+// @Success      201         {object}  models.Enrollment
+// @Failure      400         {object}  map[string]string  "Invalid input"
+// @Failure      500         {object}  map[string]string  "Server error"
+// @Router       /enrollment [post]
 func CreateEnrollment(c *fiber.Ctx) error {
 	var enrollment models.Enrollment
 
@@ -30,6 +41,14 @@ func CreateEnrollment(c *fiber.Ctx) error {
 	return c.Status(201).JSON(enrollment)
 }
 
+// GetEnrollments godoc
+// @Summary      List all enrollments
+// @Description  GetEnrollments retrieves all Enrollment records with associated Learner and Class
+// @Tags         Enrollments
+// @Produce      json
+// @Success      200         {array}   models.Enrollment
+// @Failure      500         {object}  map[string]string  "Server error"
+// @Router       /enrollments [get]
 func GetEnrollments(c *fiber.Ctx) error {
 	enrollments := []models.Enrollment{}
 	if err := db.Preload("Learner").Preload("Class").Find(&enrollments).Error; err != nil {
@@ -42,6 +61,17 @@ func findEnrollment(id int, enrollment *models.Enrollment) error {
 	return db.Preload("Learner").Preload("Class").First(enrollment, "id = ?", id).Error
 }
 
+// GetEnrollment godoc
+// @Summary      Get enrollment by ID
+// @Description  GetEnrollment retrieves a single Enrollment by its ID, including related Learner and Class
+// @Tags         Enrollments
+// @Produce      json
+// @Param        id   path      int  true  "Enrollment ID"
+// @Success      200  {object}  models.Enrollment
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Enrollment not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /enrollment/{id} [get]
 func GetEnrollment(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetEnrollment(c *fiber.Ctx) error {
 	return c.Status(200).JSON(enrollment)
 }
 
+// UpdateEnrollment godoc
+// @Summary      Update an existing enrollment
+// @Description  UpdateEnrollment updates an Enrollment record by its ID
+// @Tags         Enrollments
+// @Accept       json
+// @Produce      json
+// @Param        id           path      int                  true  "Enrollment ID"
+// @Param        enrollment   body      models.Enrollment    true  "Updated enrollment payload"
+// @Success      200          {object}  models.Enrollment
+// @Failure      400          {object}  map[string]string  "Invalid input"
+// @Failure      404          {object}  map[string]string  "Enrollment not found"
+// @Failure      500          {object}  map[string]string  "Server error"
+// @Router       /enrollment/{id} [put]
 func UpdateEnrollment(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -92,6 +135,17 @@ func UpdateEnrollment(c *fiber.Ctx) error {
 
 }
 
+// DeleteEnrollment godoc
+// @Summary      Delete an enrollment by ID
+// @Description  DeleteEnrollment removes an Enrollment record by its ID
+// @Tags         Enrollments
+// @Produce      json
+// @Param        id   path      int  true  "Enrollment ID"
+// @Success      200  {string}  string  "Successfully deleted enrollment"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Enrollment not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /enrollment/{id} [delete]
 func DeleteEnrollment(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/learner_handler.go
+++ b/handlers/learner_handler.go
@@ -16,6 +16,17 @@ func LearnerRoutes(app *fiber.App) {
 	app.Delete("/learner/:id", DeleteLearner)
 }
 
+// CreateLearner godoc
+// @Summary      Create a new learner
+// @Description  CreateLearner creates a new Learner record
+// @Tags         Learners
+// @Accept       json
+// @Produce      json
+// @Param        learner  body      models.Learner  true  "Learner payload"
+// @Success      201      {object}  models.Learner
+// @Failure      400      {object}  map[string]string  "Invalid input"
+// @Failure      500      {object}  map[string]string  "Server error"
+// @Router       /learner [post]
 func CreateLearner(c *fiber.Ctx) error {
 	var learner models.Learner
 
@@ -30,6 +41,14 @@ func CreateLearner(c *fiber.Ctx) error {
 	return c.Status(201).JSON(learner)
 }
 
+// GetLearners godoc
+// @Summary      List all learners
+// @Description  GetLearners retrieves all Learner records
+// @Tags         Learners
+// @Produce      json
+// @Success      200      {array}   models.Learner
+// @Failure      500      {object}  map[string]string  "Server error"
+// @Router       /learners [get]
 func GetLearners(c *fiber.Ctx) error {
 	learners := []models.Learner{}
 	if err := db.Find(&learners).Error; err != nil {
@@ -43,6 +62,17 @@ func findLearner(id int, learner *models.Learner) error {
 	return db.First(learner, "id = ?", id).Error
 }
 
+// GetLearner godoc
+// @Summary      Get learner by ID
+// @Description  GetLearner retrieves a single Learner by its ID
+// @Tags         Learners
+// @Produce      json
+// @Param        id   path      int  true  "Learner ID"
+// @Success      200  {object}  models.Learner
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Learner not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /learner/{id} [get]
 func GetLearner(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -63,6 +93,17 @@ func GetLearner(c *fiber.Ctx) error {
 	return c.Status(200).JSON(learner)
 }
 
+// DeleteLearner godoc
+// @Summary      Delete a learner by ID
+// @Description  DeleteLearner removes a Learner record by its ID
+// @Tags         Learners
+// @Produce      json
+// @Param        id   path      int  true  "Learner ID"
+// @Success      200  {string}  string  "Successfully deleted Learner"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Learner not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /learner/{id} [delete]
 func DeleteLearner(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/learner_handler.go
+++ b/handlers/learner_handler.go
@@ -22,8 +22,8 @@ func LearnerRoutes(app *fiber.App) {
 // @Tags         Learners
 // @Accept       json
 // @Produce      json
-// @Param        learner  body      models.Learner  true  "Learner payload"
-// @Success      201      {object}  models.Learner
+// @Param        learner  body      models.LearnerDoc  true  "Learner payload"
+// @Success      201      {object}  models.LearnerDoc
 // @Failure      400      {object}  map[string]string  "Invalid input"
 // @Failure      500      {object}  map[string]string  "Server error"
 // @Router       /learner [post]
@@ -46,7 +46,7 @@ func CreateLearner(c *fiber.Ctx) error {
 // @Description  GetLearners retrieves all Learner records
 // @Tags         Learners
 // @Produce      json
-// @Success      200      {array}   models.Learner
+// @Success      200      {array}   models.LearnerDoc
 // @Failure      500      {object}  map[string]string  "Server error"
 // @Router       /learners [get]
 func GetLearners(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findLearner(id int, learner *models.Learner) error {
 // @Tags         Learners
 // @Produce      json
 // @Param        id   path      int  true  "Learner ID"
-// @Success      200  {object}  models.Learner
+// @Success      200  {object}  models.LearnerDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Learner not found"
 // @Failure      500  {object}  map[string]string  "Server error"

--- a/handlers/notification_handler.go
+++ b/handlers/notification_handler.go
@@ -22,8 +22,8 @@ func NotificationRoutes(app *fiber.App) {
 // @Tags         Notifications
 // @Accept       json
 // @Produce      json
-// @Param        notification  body      models.Notification  true  "Notification payload"
-// @Success      201           {object}  models.Notification
+// @Param        notification  body      models.NotificationDoc  true  "Notification payload"
+// @Success      201           {object}  models.NotificationDoc
 // @Failure      400           {object}  map[string]string  "Invalid input"
 // @Failure      500           {object}  map[string]string  "Server error"
 // @Router       /notification [post]
@@ -46,7 +46,7 @@ func CreateNotification(c *fiber.Ctx) error {
 // @Description  GetNotifications retrieves all Notification records with associated User
 // @Tags         Notifications
 // @Produce      json
-// @Success      200           {array}   models.Notification
+// @Success      200           {array}   models.NotificationDoc
 // @Failure      500           {object}  map[string]string  "Server error"
 // @Router       /notifications [get]
 func GetNotifications(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findNotification(id int, notification *models.Notification) error {
 // @Tags         Notifications
 // @Produce      json
 // @Param        id   path      int  true  "Notification ID"
-// @Success      200  {object}  models.Notification
+// @Success      200  {object}  models.NotificationDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Notification not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -99,8 +99,8 @@ func GetNotification(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id            path      int                 true  "Notification ID"
-// @Param        notification  body      models.Notification  true  "Updated notification payload"
-// @Success      200           {object}  models.Notification
+// @Param        notification  body      models.NotificationDoc  true  "Updated notification payload"
+// @Success      200           {object}  models.NotificationDoc
 // @Failure      400           {object}  map[string]string  "Invalid input"
 // @Failure      404           {object}  map[string]string  "Notification not found"
 // @Failure      500           {object}  map[string]string  "Server error"

--- a/handlers/notification_handler.go
+++ b/handlers/notification_handler.go
@@ -16,6 +16,17 @@ func NotificationRoutes(app *fiber.App) {
 	app.Delete("/notification/:id", DeleteNotification)
 }
 
+// CreateNotification godoc
+// @Summary      Create a new notification
+// @Description  CreateNotification creates a new Notification record
+// @Tags         Notifications
+// @Accept       json
+// @Produce      json
+// @Param        notification  body      models.Notification  true  "Notification payload"
+// @Success      201           {object}  models.Notification
+// @Failure      400           {object}  map[string]string  "Invalid input"
+// @Failure      500           {object}  map[string]string  "Server error"
+// @Router       /notification [post]
 func CreateNotification(c *fiber.Ctx) error {
 	var notification models.Notification
 
@@ -30,6 +41,14 @@ func CreateNotification(c *fiber.Ctx) error {
 	return c.Status(201).JSON(notification)
 }
 
+// GetNotifications godoc
+// @Summary      List all notifications
+// @Description  GetNotifications retrieves all Notification records with associated User
+// @Tags         Notifications
+// @Produce      json
+// @Success      200           {array}   models.Notification
+// @Failure      500           {object}  map[string]string  "Server error"
+// @Router       /notifications [get]
 func GetNotifications(c *fiber.Ctx) error {
 	var notifications []models.Notification
 	if err := db.Preload("User").Find(&notifications).Error; err != nil {
@@ -42,6 +61,17 @@ func findNotification(id int, notification *models.Notification) error {
 	return db.Preload("User").First(notification, "id = ?", id).Error
 }
 
+// GetNotification godoc
+// @Summary      Get notification by ID
+// @Description  GetNotification retrieves a single Notification by its ID, including the User
+// @Tags         Notifications
+// @Produce      json
+// @Param        id   path      int  true  "Notification ID"
+// @Success      200  {object}  models.Notification
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Notification not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /notification/{id} [get]
 func GetNotification(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetNotification(c *fiber.Ctx) error {
 	return c.Status(200).JSON(notification)
 }
 
+// UpdateNotification godoc
+// @Summary      Update an existing notification
+// @Description  UpdateNotification updates a Notification record by its ID
+// @Tags         Notifications
+// @Accept       json
+// @Produce      json
+// @Param        id            path      int                 true  "Notification ID"
+// @Param        notification  body      models.Notification  true  "Updated notification payload"
+// @Success      200           {object}  models.Notification
+// @Failure      400           {object}  map[string]string  "Invalid input"
+// @Failure      404           {object}  map[string]string  "Notification not found"
+// @Failure      500           {object}  map[string]string  "Server error"
+// @Router       /notification/{id} [put]
 func UpdateNotification(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -91,6 +134,17 @@ func UpdateNotification(c *fiber.Ctx) error {
 	return c.Status(200).JSON(notification)
 }
 
+// DeleteNotification godoc
+// @Summary      Delete a notification by ID
+// @Description  DeleteNotification removes a Notification record by its ID
+// @Tags         Notifications
+// @Produce      json
+// @Param        id   path      int  true  "Notification ID"
+// @Success      200  {string}  string  "Successfully deleted notification"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Notification not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /notification/{id} [delete]
 func DeleteNotification(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/report_handler.go
+++ b/handlers/report_handler.go
@@ -16,6 +16,17 @@ func ReportRoutes(app *fiber.App) {
 	app.Delete("/report/:id", DeleteReport)
 }
 
+// CreateReport godoc
+// @Summary      Create a new report
+// @Description  CreateReport creates a new Report record
+// @Tags         Reports
+// @Accept       json
+// @Produce      json
+// @Param        report  body      models.Report  true  "Report payload"
+// @Success      201     {object}  models.Report
+// @Failure      400     {object}  map[string]string  "Invalid input"
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /report [post]
 func CreateReport(c *fiber.Ctx) error {
 	var report models.Report
 
@@ -30,6 +41,14 @@ func CreateReport(c *fiber.Ctx) error {
 	return c.Status(201).JSON(report)
 }
 
+// GetReports godoc
+// @Summary      List all reports
+// @Description  GetReports retrieves all Report records with Reporter and Reported relations
+// @Tags         Reports
+// @Produce      json
+// @Success      200     {array}   models.Report
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /reports [get]
 func GetReports(c *fiber.Ctx) error {
 	reports := []models.Report{}
 	if err := db.Preload("Reporter").Preload("Reported").Find(&reports).Error; err != nil {
@@ -42,6 +61,17 @@ func findReport(id int, report *models.Report) error {
 	return db.Preload("Reporter").Preload("Reported").First(report, "id = ?", id).Error
 }
 
+// GetReport godoc
+// @Summary      Get report by ID
+// @Description  GetReport retrieves a single Report by its ID, including Reporter and Reported
+// @Tags         Reports
+// @Produce      json
+// @Param        id   path      int  true  "Report ID"
+// @Success      200  {object}  models.Report
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Report not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /report/{id} [get]
 func GetReport(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -62,6 +92,19 @@ func GetReport(c *fiber.Ctx) error {
 	return c.Status(200).JSON(report)
 }
 
+// UpdateReport godoc
+// @Summary      Update an existing report
+// @Description  UpdateReport updates a Report record by its ID
+// @Tags         Reports
+// @Accept       json
+// @Produce      json
+// @Param        id      path      int             true  "Report ID"
+// @Param        report  body      models.Report   true  "Updated report payload"
+// @Success      200     {object}  models.Report
+// @Failure      400     {object}  map[string]string  "Invalid input"
+// @Failure      404     {object}  map[string]string  "Report not found"
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /report/{id} [put]
 func UpdateReport(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -91,6 +134,17 @@ func UpdateReport(c *fiber.Ctx) error {
 	return c.Status(200).JSON(report)
 }
 
+// DeleteReport godoc
+// @Summary      Delete a report by ID
+// @Description  DeleteReport removes a Report record by its ID
+// @Tags         Reports
+// @Produce      json
+// @Param        id   path      int  true  "Report ID"
+// @Success      200  {string}  string  "Successfully deleted Report"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Report not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /report/{id} [delete]
 func DeleteReport(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/report_handler.go
+++ b/handlers/report_handler.go
@@ -22,8 +22,8 @@ func ReportRoutes(app *fiber.App) {
 // @Tags         Reports
 // @Accept       json
 // @Produce      json
-// @Param        report  body      models.Report  true  "Report payload"
-// @Success      201     {object}  models.Report
+// @Param        report  body      models.ReportDoc  true  "Report payload"
+// @Success      201     {object}  models.ReportDoc
 // @Failure      400     {object}  map[string]string  "Invalid input"
 // @Failure      500     {object}  map[string]string  "Server error"
 // @Router       /report [post]
@@ -46,7 +46,7 @@ func CreateReport(c *fiber.Ctx) error {
 // @Description  GetReports retrieves all Report records with Reporter and Reported relations
 // @Tags         Reports
 // @Produce      json
-// @Success      200     {array}   models.Report
+// @Success      200     {array}   models.ReportDoc
 // @Failure      500     {object}  map[string]string  "Server error"
 // @Router       /reports [get]
 func GetReports(c *fiber.Ctx) error {
@@ -67,7 +67,7 @@ func findReport(id int, report *models.Report) error {
 // @Tags         Reports
 // @Produce      json
 // @Param        id   path      int  true  "Report ID"
-// @Success      200  {object}  models.Report
+// @Success      200  {object}  models.ReportDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Report not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -99,8 +99,8 @@ func GetReport(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id      path      int             true  "Report ID"
-// @Param        report  body      models.Report   true  "Updated report payload"
-// @Success      200     {object}  models.Report
+// @Param        report  body      models.ReportDoc   true  "Updated report payload"
+// @Success      200     {object}  models.ReportDoc
 // @Failure      400     {object}  map[string]string  "Invalid input"
 // @Failure      404     {object}  map[string]string  "Report not found"
 // @Failure      500     {object}  map[string]string  "Server error"

--- a/handlers/review_handler.go
+++ b/handlers/review_handler.go
@@ -22,8 +22,8 @@ func ReviewRoutes(app *fiber.App) {
 // @Tags         Reviews
 // @Accept       json
 // @Produce      json
-// @Param        review  body      models.Review  true  "Review payload"
-// @Success      201     {object}  models.Review
+// @Param        review  body      models.ReviewDoc  true  "Review payload"
+// @Success      201     {object}  models.ReviewDoc
 // @Failure      400     {object}  map[string]string  "Invalid input or rating out of range"
 // @Failure      500     {object}  map[string]string  "Server error"
 // @Router       /review [post]
@@ -50,7 +50,7 @@ func CreateReview(c *fiber.Ctx) error {
 // @Description  GetReviews retrieves all Review records with related Learner and Class
 // @Tags         Reviews
 // @Produce      json
-// @Success      200     {array}   models.Review
+// @Success      200     {array}   models.ReviewDoc
 // @Failure      500     {object}  map[string]string  "Server error"
 // @Router       /reviews [get]
 func GetReviews(c *fiber.Ctx) error {
@@ -71,7 +71,7 @@ func findReview(id int, review *models.Review) error {
 // @Tags         Reviews
 // @Produce      json
 // @Param        id   path      int  true  "Review ID"
-// @Success      200  {object}  models.Review
+// @Success      200  {object}  models.ReviewDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Review not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -103,8 +103,8 @@ func GetReview(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id      path      int            true  "Review ID"
-// @Param        review  body      models.Review  true  "Updated review payload"
-// @Success      200     {object}  models.Review
+// @Param        review  body      models.ReviewDoc  true  "Updated review payload"
+// @Success      200     {object}  models.ReviewDoc
 // @Failure      400     {object}  map[string]string  "Invalid input or rating out of range"
 // @Failure      404     {object}  map[string]string  "Review not found"
 // @Failure      500     {object}  map[string]string  "Server error"

--- a/handlers/review_handler.go
+++ b/handlers/review_handler.go
@@ -16,6 +16,17 @@ func ReviewRoutes(app *fiber.App) {
 	app.Delete("/review/:id", DeleteReview)
 }
 
+// CreateReview godoc
+// @Summary      Create a new review
+// @Description  CreateReview creates a new Review record with rating validation
+// @Tags         Reviews
+// @Accept       json
+// @Produce      json
+// @Param        review  body      models.Review  true  "Review payload"
+// @Success      201     {object}  models.Review
+// @Failure      400     {object}  map[string]string  "Invalid input or rating out of range"
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /review [post]
 func CreateReview(c *fiber.Ctx) error {
 	var review models.Review
 
@@ -34,6 +45,14 @@ func CreateReview(c *fiber.Ctx) error {
 	return c.Status(201).JSON(review)
 }
 
+// GetReviews godoc
+// @Summary      List all reviews
+// @Description  GetReviews retrieves all Review records with related Learner and Class
+// @Tags         Reviews
+// @Produce      json
+// @Success      200     {array}   models.Review
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /reviews [get]
 func GetReviews(c *fiber.Ctx) error {
 	var reviews []models.Review
 	if err := db.Preload("Learner").Preload("Class").Find(&reviews).Error; err != nil {
@@ -46,6 +65,17 @@ func findReview(id int, review *models.Review) error {
 	return db.Preload("Learner").Preload("Class").First(review, "id = ?", id).Error
 }
 
+// GetReview godoc
+// @Summary      Get review by ID
+// @Description  GetReview retrieves a single Review by its ID, including related Learner and Class
+// @Tags         Reviews
+// @Produce      json
+// @Param        id   path      int  true  "Review ID"
+// @Success      200  {object}  models.Review
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Review not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /review/{id} [get]
 func GetReview(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -66,6 +96,19 @@ func GetReview(c *fiber.Ctx) error {
 	return c.Status(200).JSON(review)
 }
 
+// UpdateReview godoc
+// @Summary      Update an existing review
+// @Description  UpdateReview updates a Review record by its ID; only Rating and Comment fields
+// @Tags         Reviews
+// @Accept       json
+// @Produce      json
+// @Param        id      path      int            true  "Review ID"
+// @Param        review  body      models.Review  true  "Updated review payload"
+// @Success      200     {object}  models.Review
+// @Failure      400     {object}  map[string]string  "Invalid input or rating out of range"
+// @Failure      404     {object}  map[string]string  "Review not found"
+// @Failure      500     {object}  map[string]string  "Server error"
+// @Router       /review/{id} [put]
 func UpdateReview(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -105,6 +148,17 @@ func UpdateReview(c *fiber.Ctx) error {
 	return c.Status(200).JSON(review)
 }
 
+// DeleteReview godoc
+// @Summary      Delete a review by ID
+// @Description  DeleteReview removes a Review record by its ID
+// @Tags         Reviews
+// @Produce      json
+// @Param        id   path      int  true  "Review ID"
+// @Success      200  {string}  string  "Successfully deleted review"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Review not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /review/{id} [delete]
 func DeleteReview(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/teacher_handler.go
+++ b/handlers/teacher_handler.go
@@ -22,8 +22,8 @@ func TeacherRoutes(app *fiber.App) {
 // @Tags         Teachers
 // @Accept       json
 // @Produce      json
-// @Param        teacher  body      models.Teacher  true  "Teacher payload"
-// @Success      201      {object}  models.Teacher
+// @Param        teacher  body      models.TeacherDoc  true  "Teacher payload"
+// @Success      201      {object}  models.TeacherDoc
 // @Failure      400      {object}  map[string]string  "Invalid input"
 // @Failure      500      {object}  map[string]string  "Server error"
 // @Router       /teacher [post]
@@ -46,7 +46,7 @@ func CreateTeacher(c *fiber.Ctx) error {
 // @Description  GetTeachers retrieves all Teacher records
 // @Tags         Teachers
 // @Produce      json
-// @Success      200  {array}   models.Teacher
+// @Success      200  {array}   models.TeacherDoc
 // @Failure      500  {object}  map[string]string  "Server error"
 // @Router       /teachers [get]
 func GetTeachers(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findTeacher(id int, teacher *models.Teacher) error {
 // @Tags         Teachers
 // @Produce      json
 // @Param        id   path      int  true  "Teacher ID"
-// @Success      200  {object}  models.Teacher
+// @Success      200  {object}  models.TeacherDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "Teacher not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -100,8 +100,8 @@ func GetTeacher(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id       path      int              true  "Teacher ID"
-// @Param        teacher  body      models.Teacher   true  "Updated teacher payload"
-// @Success      200      {object}  models.Teacher
+// @Param        teacher  body      models.TeacherDoc   true  "Updated teacher payload"
+// @Success      200      {object}  models.TeacherDoc
 // @Failure      400      {object}  map[string]string  "Invalid input"
 // @Failure      404      {object}  map[string]string  "Teacher not found"
 // @Failure      500      {object}  map[string]string  "Server error"

--- a/handlers/teacher_handler.go
+++ b/handlers/teacher_handler.go
@@ -16,6 +16,17 @@ func TeacherRoutes(app *fiber.App) {
 	app.Delete("/teacher/:id", DeleteTeacher)
 }
 
+// CreateTeacher godoc
+// @Summary      Create a new teacher
+// @Description  CreateTeacher creates a new Teacher record
+// @Tags         Teachers
+// @Accept       json
+// @Produce      json
+// @Param        teacher  body      models.Teacher  true  "Teacher payload"
+// @Success      201      {object}  models.Teacher
+// @Failure      400      {object}  map[string]string  "Invalid input"
+// @Failure      500      {object}  map[string]string  "Server error"
+// @Router       /teacher [post]
 func CreateTeacher(c *fiber.Ctx) error {
 	var teacher models.Teacher
 
@@ -30,6 +41,14 @@ func CreateTeacher(c *fiber.Ctx) error {
 	return c.Status(201).JSON(teacher)
 }
 
+// GetTeachers godoc
+// @Summary      List all teachers
+// @Description  GetTeachers retrieves all Teacher records
+// @Tags         Teachers
+// @Produce      json
+// @Success      200  {array}   models.Teacher
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /teachers [get]
 func GetTeachers(c *fiber.Ctx) error {
 	teachers := []models.Teacher{}
 	if err := db.Find(&teachers).Error; err != nil {
@@ -43,6 +62,17 @@ func findTeacher(id int, teacher *models.Teacher) error {
 	return db.First(teacher, "id = ?", id).Error
 }
 
+// GetTeacher godoc
+// @Summary      Get teacher by ID
+// @Description  GetTeacher retrieves a single Teacher by its ID
+// @Tags         Teachers
+// @Produce      json
+// @Param        id   path      int  true  "Teacher ID"
+// @Success      200  {object}  models.Teacher
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Teacher not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /teacher/{id} [get]
 func GetTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -63,6 +93,19 @@ func GetTeacher(c *fiber.Ctx) error {
 	return c.Status(200).JSON(teacher)
 }
 
+// UpdateTeacher godoc
+// @Summary      Update an existing teacher
+// @Description  UpdateTeacher updates a Teacher record by its ID
+// @Tags         Teachers
+// @Accept       json
+// @Produce      json
+// @Param        id       path      int              true  "Teacher ID"
+// @Param        teacher  body      models.Teacher   true  "Updated teacher payload"
+// @Success      200      {object}  models.Teacher
+// @Failure      400      {object}  map[string]string  "Invalid input"
+// @Failure      404      {object}  map[string]string  "Teacher not found"
+// @Failure      500      {object}  map[string]string  "Server error"
+// @Router       /teacher/{id} [put]
 func UpdateTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -92,6 +135,17 @@ func UpdateTeacher(c *fiber.Ctx) error {
 	return c.Status(200).JSON(teacher)
 }
 
+// DeleteTeacher godoc
+// @Summary      Delete a teacher by ID
+// @Description  DeleteTeacher removes a Teacher record by its ID
+// @Tags         Teachers
+// @Produce      json
+// @Param        id   path      int  true  "Teacher ID"
+// @Success      200  {string}  string  "Successfully deleted Teacher"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "Teacher not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /teacher/{id} [delete]
 func DeleteTeacher(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -22,8 +22,8 @@ func UserRoutes(app *fiber.App) {
 // @Tags         Users
 // @Accept       json
 // @Produce      json
-// @Param        user  body      models.User  true  "User payload"
-// @Success      201   {object}  models.User
+// @Param        user  body      models.UserDoc  true  "User payload"
+// @Success      201   {object}  models.UserDoc
 // @Failure      400   {object}  map[string]string  "Invalid input"
 // @Failure      500   {object}  map[string]string  "Server error"
 // @Router       /user [post]
@@ -46,7 +46,7 @@ func CreateUser(c *fiber.Ctx) error {
 // @Description  GetUsers retrieves all user records
 // @Tags         Users
 // @Produce      json
-// @Success      200  {array}   models.User
+// @Success      200  {array}   models.UserDoc
 // @Failure      500  {object}  map[string]string  "Server error"
 // @Router       /users [get]
 func GetUsers(c *fiber.Ctx) error {
@@ -68,7 +68,7 @@ func findUser(id int, user *models.User) error {
 // @Tags         Users
 // @Produce      json
 // @Param        id   path      int  true  "User ID"
-// @Success      200  {object}  models.User
+// @Success      200  {object}  models.UserDoc
 // @Failure      400  {object}  map[string]string  "Invalid ID"
 // @Failure      404  {object}  map[string]string  "User not found"
 // @Failure      500  {object}  map[string]string  "Server error"
@@ -100,8 +100,8 @@ func GetUser(c *fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        id    path      int         true  "User ID"
-// @Param        user  body      models.User true  "Updated user payload"
-// @Success      200   {object}  models.User
+// @Param        user  body      models.UserDoc true  "Updated user payload"
+// @Success      200   {object}  models.UserDoc
 // @Failure      400   {object}  map[string]string  "Invalid input"
 // @Failure      404   {object}  map[string]string  "User not found"
 // @Failure      500   {object}  map[string]string  "Server error"

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -16,6 +16,17 @@ func UserRoutes(app *fiber.App) {
 	app.Delete("/user/:id", DeleteUser)
 }
 
+// CreateUser godoc
+// @Summary      Create a new user
+// @Description  CreateUser creates a new user record
+// @Tags         Users
+// @Accept       json
+// @Produce      json
+// @Param        user  body      models.User  true  "User payload"
+// @Success      201   {object}  models.User
+// @Failure      400   {object}  map[string]string  "Invalid input"
+// @Failure      500   {object}  map[string]string  "Server error"
+// @Router       /user [post]
 func CreateUser(c *fiber.Ctx) error {
 	var user models.User
 
@@ -30,6 +41,14 @@ func CreateUser(c *fiber.Ctx) error {
 	return c.Status(201).JSON(user)
 }
 
+// GetUsers godoc
+// @Summary      List all users
+// @Description  GetUsers retrieves all user records
+// @Tags         Users
+// @Produce      json
+// @Success      200  {array}   models.User
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /users [get]
 func GetUsers(c *fiber.Ctx) error {
 	users := []models.User{}
 	if err := db.Find(&users).Error; err != nil {
@@ -43,6 +62,17 @@ func findUser(id int, user *models.User) error {
 	return db.First(user, "id = ?", id).Error
 }
 
+// GetUser godoc
+// @Summary      Get user by ID
+// @Description  GetUser retrieves a single user by its ID
+// @Tags         Users
+// @Produce      json
+// @Param        id   path      int  true  "User ID"
+// @Success      200  {object}  models.User
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "User not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /user/{id} [get]
 func GetUser(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -63,6 +93,19 @@ func GetUser(c *fiber.Ctx) error {
 	return c.Status(200).JSON(user)
 }
 
+// UpdateUser godoc
+// @Summary      Update an existing user
+// @Description  UpdateUser updates a user record by its ID
+// @Tags         Users
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int         true  "User ID"
+// @Param        user  body      models.User true  "Updated user payload"
+// @Success      200   {object}  models.User
+// @Failure      400   {object}  map[string]string  "Invalid input"
+// @Failure      404   {object}  map[string]string  "User not found"
+// @Failure      500   {object}  map[string]string  "Server error"
+// @Router       /user/{id} [put]
 func UpdateUser(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 
@@ -92,6 +135,17 @@ func UpdateUser(c *fiber.Ctx) error {
 	return c.Status(200).JSON(user)
 }
 
+// DeleteUser godoc
+// @Summary      Delete a user by ID
+// @Description  DeleteUser removes a user record by its ID
+// @Tags         Users
+// @Produce      json
+// @Param        id   path      int  true  "User ID"
+// @Success      200  {string}  string  "Successfully deleted User"
+// @Failure      400  {object}  map[string]string  "Invalid ID"
+// @Failure      404  {object}  map[string]string  "User not found"
+// @Failure      500  {object}  map[string]string  "Server error"
+// @Router       /user/{id} [delete]
 func DeleteUser(c *fiber.Ctx) error {
 	id, err := c.ParamsInt("id")
 

--- a/main.go
+++ b/main.go
@@ -51,7 +51,13 @@ func main() {
 		})
 	})
 
-	app.Get("/swagger/*", swagger.HandlerDefault)
+	//custom swagger UI
+	app.Get("/swagger/*", swagger.New(swagger.Config{
+		URL:                      "http://localhost:8000/swagger/doc.json", // swagger.json location
+		DeepLinking:              true,
+		DocExpansion:             "false",
+		DefaultModelsExpandDepth: 2, //expand models
+	}))
 
 	handlers.AllRoutes(db, app) // Register admin routes
 	// Define the /users route and handler inline

--- a/models/admin.go
+++ b/models/admin.go
@@ -5,3 +5,9 @@ import "gorm.io/gorm"
 type Admin struct {
 	gorm.Model
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type AdminDoc struct {
+	ID uint `json:"id" example:"43"`
+}

--- a/models/ban_learner.go
+++ b/models/ban_learner.go
@@ -15,3 +15,13 @@ type BanDetailsLearner struct {
 
 	Learner Learner `gorm:"foreignKey:LearnerID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type BanDetailsLearnerDoc struct {
+	ID             uint      `json:"id" example:"1"`
+	LearnerID      uint      `json:"learner_id" example:"42"`
+	BanStart       time.Time `json:"ban_start" example:"2025-08-20T12:00:00Z"`
+	BanEnd         time.Time `json:"ban_end" example:"2025-08-30T12:00:00Z"`
+	BanDescription string    `json:"ban_description" example:"Spamming inappropriate content"`
+}

--- a/models/ban_teacher.go
+++ b/models/ban_teacher.go
@@ -15,3 +15,13 @@ type BanDetailsTeacher struct {
 
 	Teacher Teacher `gorm:"foreignKey:TeacherID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type BanDetailsTeacherDoc struct {
+	ID             uint      `json:"id" example:"1"`
+	TeacherID      uint      `json:"teacher_id" example:"7"`
+	BanStart       time.Time `json:"ban_start" example:"2025-08-20T12:00:00Z"`
+	BanEnd         time.Time `json:"ban_end" example:"2025-08-30T12:00:00Z"`
+	BanDescription string    `json:"ban_description" example:"Repeated policy violations"`
+}

--- a/models/class.go
+++ b/models/class.go
@@ -16,3 +16,13 @@ type Class struct {
 	Teacher    Teacher         `gorm:"foreignKey:TeacherID;references:ID;constraint:OnDelete:CASCADE"`
 	Categories []ClassCategory `gorm:"many2many:class_class_categories;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type ClassDoc struct {
+	ID                 uint      `json:"id" example:"21"`
+	TeacherID          uint      `json:"teacher_id" example:"7"`
+	LearnerLimit       int       `json:"learner_limit" example:"50"`
+	ClassDescription   string    `json:"class_description" example:"Advanced Python programming course"`
+	EnrollmentDeadline time.Time `json:"enrollment_deadline" example:"2025-09-10T23:59:59Z"`
+}

--- a/models/class_category.go
+++ b/models/class_category.go
@@ -8,3 +8,11 @@ type ClassCategory struct {
 
 	Classes []Class `gorm:"many2many:class_class_categories;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type ClassCategoryDoc struct {
+	ID            uint       `json:"id" example:"3"`
+	ClassCategory string     `json:"class_category" example:"Mathematics"`
+	Classes       []ClassDoc `json:"classes,omitempty"`
+}

--- a/models/class_session.go
+++ b/models/class_session.go
@@ -17,3 +17,15 @@ type ClassSession struct {
 
 	Class Class `gorm:"foreignKey:ClassID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type ClassSessionDoc struct {
+	ID                 uint      `json:"id" example:"15"`
+	ClassID            uint      `json:"class_id" example:"12"`
+	Description        string    `json:"description" example:"Weekly tutoring session for calculus"`
+	EnrollmentDeadline time.Time `json:"enrollment_deadline" example:"2025-09-01T23:59:59Z"`
+	ClassStart         time.Time `json:"class_start" example:"2025-09-05T14:00:00Z"`
+	ClassFinish        time.Time `json:"class_finish" example:"2025-09-05T16:00:00Z"`
+	ClassStatus        string    `json:"class_status" example:"Scheduled"`
+}

--- a/models/enrollment.go
+++ b/models/enrollment.go
@@ -13,3 +13,12 @@ type Enrollment struct {
 	Learner Learner `gorm:"foreignKey:LearnerID;references:ID;constraint:OnDelete:CASCADE"`
 	Class   Class   `gorm:"foreignKey:ClassID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type EnrollmentDoc struct {
+	ID               uint   `json:"id" example:"101"`
+	LearnerID        uint   `json:"learner_id" example:"42"`
+	ClassID          uint   `json:"class_id" example:"21"`
+	EnrollmentStatus string `json:"enrollment_status" example:"active"`
+}

--- a/models/learner.go
+++ b/models/learner.go
@@ -5,3 +5,9 @@ import "gorm.io/gorm"
 type Learner struct {
 	gorm.Model
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type LearnerDoc struct {
+	ID uint `json:"id" example:"42"`
+}

--- a/models/notification.go
+++ b/models/notification.go
@@ -16,3 +16,14 @@ type Notification struct {
 
 	User User `gorm:"foreignKey:UserID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type NotificationDoc struct {
+	ID                      uint      `json:"id" example:"100"`
+	UserID                  uint      `json:"user_id" example:"42"`
+	NotificationType        string    `json:"notification_type" example:"System Alert"`
+	NotificationDescription string    `json:"notification_description" example:"Your class has been rescheduled"`
+	NotificationDate        time.Time `json:"notification_date" example:"2025-08-20T15:04:05Z"`
+	ReadFlag                bool      `json:"read_flag" example:"false"`
+}

--- a/models/report.go
+++ b/models/report.go
@@ -18,3 +18,15 @@ type Report struct {
 	Reporter User `gorm:"foreignKey:ReportUserID;constraint:OnDelete:CASCADE"`
 	Reported User `gorm:"foreignKey:ReportedUserID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type ReportDoc struct {
+	ID                uint      `json:"id" example:"12"`
+	ReportUserID      uint      `json:"report_user_id" example:"5"`
+	ReportedUserID    uint      `json:"reported_user_id" example:"8"`
+	ReportType        string    `json:"report_type" example:"Abuse"`
+	ReportDescription string    `json:"report_description" example:"User sent inappropriate messages"`
+	ReportPicture     string    `json:"report_picture" example:"base64-encoded-image-string"`
+	ReportDate        time.Time `json:"report_date" example:"2025-08-20T14:30:00Z"`
+}

--- a/models/review.go
+++ b/models/review.go
@@ -14,3 +14,13 @@ type Review struct {
 	Learner Learner `gorm:"foreignKey:LearnerID;references:ID;constraint:OnDelete:CASCADE"`
 	Class   Class   `gorm:"foreignKey:ClassID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type ReviewDoc struct {
+	ID        uint   `json:"id" example:"101"`
+	LearnerID uint   `json:"learner_id" example:"42"`
+	ClassID   uint   `json:"class_id" example:"9"`
+	Rating    int    `json:"rating" example:"5"`
+	Comment   string `json:"comment" example:"This class was very informative and well-structured."`
+}

--- a/models/teacher.go
+++ b/models/teacher.go
@@ -6,3 +6,10 @@ type Teacher struct {
 	gorm.Model
 	Description string `gorm:"size:255"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type TeacherDoc struct {
+	ID          uint   `json:"id" example:"12"`
+	Description string `json:"description" example:"Experienced Mathematics teacher specializing in calculus and linear algebra."`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -23,3 +23,19 @@ type User struct {
 	Teacher *Teacher `gorm:"foreignKey:TeacherID;references:ID;constraint:OnDelete:SET NULL;"`
 	Admin   *Admin   `gorm:"foreignKey:AdminID;references:ID;constraint:OnDelete:SET NULL;"`
 }
+
+// ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
+
+type UserDoc struct {
+	ID             uint    `json:"id" example:"101"`
+	SessionID      string  `json:"session_id" example:"sess-abc123xyz"`
+	ProfilePicture string  `json:"profile_picture,omitempty" example:"<base64-encoded-image>"`
+	FirstName      string  `json:"first_name" example:"Alice"`
+	LastName       string  `json:"last_name" example:"Smith"`
+	Gender         string  `json:"gender" example:"Female"`
+	PhoneNumber    string  `json:"phone_number" example:"+66912345678"`
+	Balance        float64 `json:"balance" example:"250.75"`
+	LearnerID      *uint   `json:"learner_id,omitempty" example:"42"`
+	TeacherID      *uint   `json:"teacher_id,omitempty" example:"7"`
+	AdminID        *uint   `json:"admin_id,omitempty" example:"3"`
+}


### PR DESCRIPTION
- Introduced Doc-only structs for each model to enhance Swagger documentation with example values.
- Updated handlers to reference new Doc structs in Swagger annotations.
- Modified main.go to customize Swagger UI settings for better usability.