### PR TITLE
ci: fix github workflows cd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.PRIVATE_KEYSERVER_SSH_KEY }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.PORT }}
           source: "./"
           target: "~/tutorium-backend"


### PR DESCRIPTION
Fix GitHub workflows continuous deployment environment variable name mistake (`secrets.PRIVATE_KEYSERVER_SSH_KEY` -> `secrets.SERVER_SSH_KEY`) introduced by #22, #23.