### PR TITLE
ci: exclude git directory in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.PORT }}
-          source: "./"
+          source: ".,!.git"
           target: "~/tutorium-backend"
           overwrite: true
           strip_components: 0


### PR DESCRIPTION
Exclude `.git` directory in continuous deployment workflow. This reduces the deployment size, allows for faster deployments, better for security as it could exposes unnecessary details to our project's history, and there is simply no practical use for the folder in production; it doesn't need version control history, it simply needs to run the application.