### PR TITLE
fix : change parameter to godotenv in .\middleware\auth_middleware.go

### DIFF
--- a/middleware/auth_middleware.go
+++ b/middleware/auth_middleware.go
@@ -16,7 +16,7 @@ import (
 var jwtSecret []byte
 
 func init() {
-	if err := godotenv.Load(); err != nil {
+	if err := godotenv.Load("../.env"); err != nil {
 		log.Println(".env file not found, using system environment variables")
 	}
 	secretStr := os.Getenv("JWT_SECRET")


### PR DESCRIPTION
fix parameter in  godotenv.Load() from empty to "../.env" to make it access .env in root directory