### PR TITLE
ci(deploy): don't pull upstream; undo 90b1fc1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,6 @@ jobs:
               # Change to project directory
               cd ~/tutorium-backend
 
-              # fetch and merge lastest code
-              git pull
-
               echo "=== Starting deployment ==="
               echo "Current directory: $(pwd)"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,7 @@ jobs:
           port: ${{ secrets.PORT }}
           source: ".,!.git"
           target: "~/tutorium-backend"
-          overwrite: true
-          strip_components: 0
+          rm: true
 
       - name: Deploy with docker compose
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
Don't pull upstream on deployment as we already exclude the `.git` repository while copying the directory. Revert commit 90b1fc1.

cc @parinya-ao