### PR TITLE
refactor(auth): centralize JWT secret loading and reuse in login handler

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3685,17 +3685,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "Advanced Python Programming"
                 },
-                "enrollment_deadline": {
-                    "type": "string",
-                    "example": "2025-09-10T23:59:59Z"
-                },
                 "id": {
                     "type": "integer",
                     "example": 21
-                },
-                "learner_limit": {
-                    "type": "integer",
-                    "example": 50
                 },
                 "price": {
                     "type": "number",
@@ -3741,6 +3733,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer",
                     "example": 15
+                },
+                "learner_limit": {
+                    "type": "integer",
+                    "example": 50
                 }
             }
         },
@@ -3768,10 +3764,6 @@ const docTemplate = `{
         "models.LearnerDoc": {
             "type": "object",
             "properties": {
-                "ban_count": {
-                    "type": "integer",
-                    "example": 1
-                },
                 "flag_count": {
                     "type": "integer",
                     "example": 3
@@ -3921,10 +3913,6 @@ const docTemplate = `{
         "models.TeacherDoc": {
             "type": "object",
             "properties": {
-                "ban_count": {
-                    "type": "integer",
-                    "example": 1
-                },
                 "description": {
                     "type": "string",
                     "example": "Experienced Mathematics teacher specializing in calculus and linear algebra."
@@ -3953,6 +3941,10 @@ const docTemplate = `{
                 "balance": {
                     "type": "number",
                     "example": 250.75
+                },
+                "ban_count": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "first_name": {
                     "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3677,17 +3677,9 @@
                     "type": "string",
                     "example": "Advanced Python Programming"
                 },
-                "enrollment_deadline": {
-                    "type": "string",
-                    "example": "2025-09-10T23:59:59Z"
-                },
                 "id": {
                     "type": "integer",
                     "example": 21
-                },
-                "learner_limit": {
-                    "type": "integer",
-                    "example": 50
                 },
                 "price": {
                     "type": "number",
@@ -3733,6 +3725,10 @@
                 "id": {
                     "type": "integer",
                     "example": 15
+                },
+                "learner_limit": {
+                    "type": "integer",
+                    "example": 50
                 }
             }
         },
@@ -3760,10 +3756,6 @@
         "models.LearnerDoc": {
             "type": "object",
             "properties": {
-                "ban_count": {
-                    "type": "integer",
-                    "example": 1
-                },
                 "flag_count": {
                     "type": "integer",
                     "example": 3
@@ -3913,10 +3905,6 @@
         "models.TeacherDoc": {
             "type": "object",
             "properties": {
-                "ban_count": {
-                    "type": "integer",
-                    "example": 1
-                },
                 "description": {
                     "type": "string",
                     "example": "Experienced Mathematics teacher specializing in calculus and linear algebra."
@@ -3945,6 +3933,10 @@
                 "balance": {
                     "type": "number",
                     "example": 250.75
+                },
+                "ban_count": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "first_name": {
                     "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -68,14 +68,8 @@ definitions:
       class_name:
         example: Advanced Python Programming
         type: string
-      enrollment_deadline:
-        example: "2025-09-10T23:59:59Z"
-        type: string
       id:
         example: 21
-        type: integer
-      learner_limit:
-        example: 50
         type: integer
       price:
         example: 1999.99
@@ -110,6 +104,9 @@ definitions:
       id:
         example: 15
         type: integer
+      learner_limit:
+        example: 50
+        type: integer
     type: object
   models.EnrollmentDoc:
     properties:
@@ -128,9 +125,6 @@ definitions:
     type: object
   models.LearnerDoc:
     properties:
-      ban_count:
-        example: 1
-        type: integer
       flag_count:
         example: 3
         type: integer
@@ -238,9 +232,6 @@ definitions:
     type: object
   models.TeacherDoc:
     properties:
-      ban_count:
-        example: 1
-        type: integer
       description:
         example: Experienced Mathematics teacher specializing in calculus and linear
           algebra.
@@ -263,6 +254,9 @@ definitions:
       balance:
         example: 250.75
         type: number
+      ban_count:
+        example: 1
+        type: integer
       first_name:
         example: Alice
         type: string

--- a/handlers/login_handler.go
+++ b/handlers/login_handler.go
@@ -131,14 +131,8 @@ func LoginHandler(c *fiber.Ctx) error {
 }
 
 func generateJWT(user models.User) (string, error) {
-	if err := godotenv.Load("../.env"); err != nil {
-		log.Println(".env file not found, using system environment variables")
-	}
-	secretStr := os.Getenv("JWT_SECRET")
-	if secretStr == "" {
-		log.Fatal("JWT_SECRET environment variable is not set")
-	}
-	secret := []byte(secretStr)
+	secret := middlewares.Secret()
+
 	claims := jwt.MapClaims{
 		"user_id": user.ID,
 		"exp":     time.Now().Add(time.Hour * 24).Unix(), // token expires in 24h

--- a/models/class.go
+++ b/models/class.go
@@ -10,7 +10,6 @@ type Class struct {
 	gorm.Model
 	TeacherID          uint      `json:"teacher_id" gorm:"not null"`
 	ClassName          string    `json:"class_name" gorm:"size:255;not null"`
-	LearnerLimit       int       `json:"learner_limit" gorm:"not null;default:50"`
 	ClassDescription   string    `json:"class_description" gorm:"size:1000"`
 	BannerPictureURL   string    `json:"banner_picture,omitempty"`
 	Price              float64   `json:"price" gorm:"type:numeric(12,2);default:0;check:price >= 0"`
@@ -27,7 +26,6 @@ type ClassDoc struct {
 	ID                 uint      `json:"id" example:"21"`
 	TeacherID          uint      `json:"teacher_id" example:"7"`
 	ClassName          string    `json:"class_name" example:"Advanced Python Programming"`
-	LearnerLimit       int       `json:"learner_limit" example:"50"`
 	ClassDescription   string    `json:"class_description" example:"Advanced Python programming course"`
 	BannerPicture      string    `json:"banner_picture,omitempty" example:"<base64-encoded-image>"`
 	Price              float64   `json:"price" example:"1999.99"`

--- a/models/class.go
+++ b/models/class.go
@@ -1,20 +1,17 @@
 package models
 
 import (
-	"time"
-
 	"gorm.io/gorm"
 )
 
 type Class struct {
 	gorm.Model
-	TeacherID          uint      `json:"teacher_id" gorm:"not null"`
-	ClassName          string    `json:"class_name" gorm:"size:255;not null"`
-	ClassDescription   string    `json:"class_description" gorm:"size:1000"`
-	BannerPictureURL   string    `json:"banner_picture,omitempty"`
-	Price              float64   `json:"price" gorm:"type:numeric(12,2);default:0;check:price >= 0"`
-	Rating             float64   `json:"rating" gorm:"type:numeric(3,2);default:0;check:rating >= 0 AND rating <= 5"`
-	EnrollmentDeadline time.Time `json:"enrollment_deadline" gorm:"not null"`
+	TeacherID        uint    `json:"teacher_id" gorm:"not null"`
+	ClassName        string  `json:"class_name" gorm:"size:255;not null"`
+	ClassDescription string  `json:"class_description" gorm:"size:1000"`
+	BannerPictureURL string  `json:"banner_picture,omitempty"`
+	Price            float64 `json:"price" gorm:"type:numeric(12,2);default:0;check:price >= 0"`
+	Rating           float64 `json:"rating" gorm:"type:numeric(3,2);default:0;check:rating >= 0 AND rating <= 5"`
 
 	Teacher    Teacher         `gorm:"foreignKey:TeacherID;references:ID;constraint:OnDelete:CASCADE"`
 	Categories []ClassCategory `gorm:"many2many:class_class_categories;constraint:OnDelete:CASCADE"`
@@ -23,12 +20,11 @@ type Class struct {
 // ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
 
 type ClassDoc struct {
-	ID                 uint      `json:"id" example:"21"`
-	TeacherID          uint      `json:"teacher_id" example:"7"`
-	ClassName          string    `json:"class_name" example:"Advanced Python Programming"`
-	ClassDescription   string    `json:"class_description" example:"Advanced Python programming course"`
-	BannerPicture      string    `json:"banner_picture,omitempty" example:"<base64-encoded-image>"`
-	Price              float64   `json:"price" example:"1999.99"`
-	Rating             float64   `json:"rating" example:"4.7"`
-	EnrollmentDeadline time.Time `json:"enrollment_deadline" example:"2025-09-10T23:59:59Z"`
+	ID               uint    `json:"id" example:"21"`
+	TeacherID        uint    `json:"teacher_id" example:"7"`
+	ClassName        string  `json:"class_name" example:"Advanced Python Programming"`
+	ClassDescription string  `json:"class_description" example:"Advanced Python programming course"`
+	BannerPicture    string  `json:"banner_picture,omitempty" example:"<base64-encoded-image>"`
+	Price            float64 `json:"price" example:"1999.99"`
+	Rating           float64 `json:"rating" example:"4.7"`
 }

--- a/models/class_session.go
+++ b/models/class_session.go
@@ -10,6 +10,7 @@ type ClassSession struct {
 	gorm.Model
 	ClassID            uint      `json:"class_id"`
 	Description        string    `json:"description" gorm:"size:1000"`
+	LearnerLimit       int       `json:"learner_limit" gorm:"not null;default:50"`
 	EnrollmentDeadline time.Time `json:"enrollment_deadline" gorm:"not null"`
 	ClassStart         time.Time `json:"class_start" gorm:"not null"`
 	ClassFinish        time.Time `json:"class_finish" gorm:"not null"`
@@ -24,6 +25,7 @@ type ClassSessionDoc struct {
 	ID                 uint      `json:"id" example:"15"`
 	ClassID            uint      `json:"class_id" example:"12"`
 	Description        string    `json:"description" example:"Weekly tutoring session for calculus"`
+	LearnerLimit       int       `json:"learner_limit" example:"50"`
 	EnrollmentDeadline time.Time `json:"enrollment_deadline" example:"2025-09-01T23:59:59Z"`
 	ClassStart         time.Time `json:"class_start" example:"2025-09-05T14:00:00Z"`
 	ClassFinish        time.Time `json:"class_finish" example:"2025-09-05T16:00:00Z"`

--- a/models/learner.go
+++ b/models/learner.go
@@ -6,7 +6,6 @@ type Learner struct {
 	gorm.Model
 	UserID    uint `json:"user_id" gorm:"unique;not null"`
 	FlagCount int  `json:"flag_count" gorm:"default:0;not null"`
-	BanCount  int  `json:"ban_count" gorm:"default:0;not null"`
 }
 
 // ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
@@ -15,5 +14,4 @@ type LearnerDoc struct {
 	ID        uint `json:"id" example:"42"`
 	UserID    uint `json:"user_id" example:"5"`
 	FlagCount int  `json:"flag_count" example:"3"`
-	BanCount  int  `json:"ban_count" example:"1"`
 }

--- a/models/teacher.go
+++ b/models/teacher.go
@@ -7,7 +7,6 @@ type Teacher struct {
 	UserID      uint   `json:"user_id" gorm:"unique;not null"`
 	Description string `json:"description" gorm:"size:255"`
 	FlagCount   int    `json:"flag_count" gorm:"default:0;not null"`
-	BanCount    int    `json:"ban_count" gorm:"default:0;not null"`
 	Email       string `json:"email" gorm:"size:100;unique;not null"`
 }
 
@@ -18,6 +17,5 @@ type TeacherDoc struct {
 	UserID      uint   `json:"user_id" example:"5"`
 	Description string `json:"description" example:"Experienced Mathematics teacher specializing in calculus and linear algebra."`
 	FlagCount   int    `json:"flag_count" example:"3"`
-	BanCount    int    `json:"ban_count" example:"1"`
 	Email       string `json:"email" example:"teacher@example.com"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	Gender            string  `json:"gender" gorm:"size:6"`
 	PhoneNumber       string  `json:"phone_number" gorm:"size:20"`
 	Balance           float64 `json:"balance" gorm:"type:numeric(12,2);default:0;check:balance >= 0"`
+	BanCount          int     `json:"ban_count" gorm:"default:0;not null"`
 
 	Learner *Learner
 	Teacher *Teacher
@@ -31,4 +32,5 @@ type UserDoc struct {
 	Gender         string  `json:"gender" example:"Female"`
 	PhoneNumber    string  `json:"phone_number" example:"+66912345678"`
 	Balance        float64 `json:"balance" example:"250.75"`
+	BanCount       int     `json:"ban_count" example:"1"`
 }


### PR DESCRIPTION
- Removed duplicate godotenv + os.Getenv calls in generateJWT
- Use shared Secret() func from auth middleware instead