### PR TITLE
fix: omit associations in all handlers to prevent unintended inserts

### DIFF
--- a/handlers/ban_learner_handler.go
+++ b/handlers/ban_learner_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func BanLearnerRoutes(app *fiber.App) {
@@ -155,7 +156,7 @@ func UpdateBanLearner(c *fiber.Ctx) error {
 		return c.Status(400).JSON(err.Error())
 	}
 
-	if err := db.Model(&banlearner).Omit("Learner").Updates(banlearner_update).Error; err != nil {
+	if err := db.Model(&banlearner).Omit(clause.Associations).Updates(banlearner_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
 

--- a/handlers/ban_teacher_handler.go
+++ b/handlers/ban_teacher_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func BanTeacherRoutes(app *fiber.App) {
@@ -155,7 +156,7 @@ func UpdateBanTeacher(c *fiber.Ctx) error {
 		return c.Status(400).JSON(err.Error())
 	}
 
-	if err := db.Model(&banteacher).Omit("Teacher").Updates(banteacher_update).Error; err != nil {
+	if err := db.Model(&banteacher).Omit(clause.Associations).Updates(banteacher_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
 

--- a/handlers/class_category_handler.go
+++ b/handlers/class_category_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func ClassCategoryRoutes(app *fiber.App) {
@@ -157,7 +158,7 @@ func UpdateClassCategory(c *fiber.Ctx) error {
 		return c.Status(400).JSON(err.Error())
 	}
 
-	if err := db.Model(&class_category).Omit("Classes").Updates(class_category_update).Error; err != nil {
+	if err := db.Model(&class_category).Omit(clause.Associations).Updates(class_category_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
 

--- a/handlers/class_handler.go
+++ b/handlers/class_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/storage"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func ClassRoutes(app *fiber.App) {
@@ -94,6 +95,7 @@ func CreateClass(c *fiber.Ctx) error {
 	if err := tx.Commit().Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
+
 	return c.Status(201).JSON(class)
 }
 
@@ -326,8 +328,7 @@ func UpdateClass(c *fiber.Ctx) error {
 	}
 
 	if err := tx.Model(&class).
-		Omit("Teacher").
-		Omit("Categories").
+		Omit(clause.Associations).
 		Updates(class_update).Error; err != nil {
 		tx.Rollback()
 		return c.Status(500).JSON(err.Error())

--- a/handlers/class_session_handler.go
+++ b/handlers/class_session_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func ClassSessionRoutes(app *fiber.App) {
@@ -157,7 +158,7 @@ func UpdateClassSession(c *fiber.Ctx) error {
 		return c.Status(400).JSON(err.Error())
 	}
 
-	if err := db.Model(&class_session).Omit("Class").Updates(class_session_update).Error; err != nil {
+	if err := db.Model(&class_session).Omit(clause.Associations).Updates(class_session_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
 

--- a/handlers/enrollment_handler.go
+++ b/handlers/enrollment_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func EnrollmentRoutes(app *fiber.App) {
@@ -156,8 +157,7 @@ func UpdateEnrollment(c *fiber.Ctx) error {
 	}
 
 	if err := db.Model(&enrollment).
-		Omit("Learner").
-		Omit("ClassSession").
+		Omit(clause.Associations).
 		Updates(enrollment_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}

--- a/handlers/notification_handler.go
+++ b/handlers/notification_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func NotificationRoutes(app *fiber.App) {
@@ -156,7 +157,7 @@ func UpdateNotification(c *fiber.Ctx) error {
 		return c.Status(400).JSON(err.Error())
 	}
 
-	if err := db.Model(&notification).Omit("User").Updates(notification_updated).Error; err != nil {
+	if err := db.Model(&notification).Omit(clause.Associations).Updates(notification_updated).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}
 

--- a/handlers/report_handler.go
+++ b/handlers/report_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/storage"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func ReportRoutes(app *fiber.App) {
@@ -199,8 +200,7 @@ func UpdateReport(c *fiber.Ctx) error {
 	}
 
 	if err := db.Model(&report).
-		Omit("Reporter").
-		Omit("Reported").
+		Omit(clause.Associations).
 		Updates(report_updated).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}

--- a/handlers/review_handler.go
+++ b/handlers/review_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/a2n2k3p4/tutorium-backend/models"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func ReviewRoutes(app *fiber.App) {
@@ -171,8 +172,7 @@ func UpdateReview(c *fiber.Ctx) error {
 	}
 
 	if err := db.Model(&review).
-		Omit("Learner").
-		Omit("Class").
+		Omit(clause.Associations).
 		Updates(review_updated).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -228,9 +228,7 @@ func UpdateUser(c *fiber.Ctx) error {
 	}
 
 	if err := db.Model(&user).
-		Omit("Learner").
-		Omit("Teacher").
-		Omit("Admin").
+		Omit(clause.Associations).
 		Updates(user_update).Error; err != nil {
 		return c.Status(500).JSON(err.Error())
 	}


### PR DESCRIPTION
- Added `.Omit(clause.Associations)` to all `update` handler to ignore associations
- Replaced previous `.Omit("Teacher").Omit("Categories")` patterns with the
  correct approach using `clause.Associations`