### PR TITLE
chore(envrc): also source envrc a directory up

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,3 +8,5 @@ eval "$(devenv direnvrc)"
 #
 # Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
 use devenv
+
+source_up


### PR DESCRIPTION
Source `.envrc` file from a directory up as well as the current directory's. Useful if this was in a nested direnv-managed directory structure.