### PR TITLE
fix(models): correct unique index on Enrollment (LearnerID + ClassSessionID)

### DIFF
--- a/models/enrollment.go
+++ b/models/enrollment.go
@@ -6,8 +6,8 @@ import (
 
 type Enrollment struct {
 	gorm.Model
-	LearnerID        uint   `json:"learner_id" gorm:"not null;uniqueIndex:idx_learner_class_enroll"`
-	ClassSessionID   uint   `json:"class_session_id" gorm:"not null;uniqueIndex:idx_learner_session_enroll"`
+	LearnerID        uint   `json:"learner_id" gorm:"not null;uniqueIndex:idx_learner_session"`
+	ClassSessionID   uint   `json:"class_session_id" gorm:"not null;uniqueIndex:idx_learner_session"`
 	EnrollmentStatus string `json:"enrollment_status" gorm:"size:20"`
 
 	Learner      Learner      `gorm:"foreignKey:LearnerID;references:ID;constraint:OnDelete:CASCADE"`


### PR DESCRIPTION
- Updated `Enrollment` model to use a single composite unique index `(idx_learner_session)` for `(LearnerID, ClassSessionID)`.
- Fix problems where one learner could only join one session and one session could only have one learner