### PR TITLE
feat(classes): add detailed class endpoints and class category management routes

### DIFF
--- a/handlers/class_handler.go
+++ b/handlers/class_handler.go
@@ -525,11 +525,15 @@ func GetClassCategoriesByClassID(c *fiber.Ctx) error {
 		return c.Status(500).SendString(err.Error())
 	}
 
-	names := make([]string, 0, len(class.Categories))
+	categories := make([]fiber.Map, 0, len(class.Categories))
 	for _, cat := range class.Categories {
-		names = append(names, cat.ClassCategory)
+		categories = append(categories, fiber.Map{
+			"id":             cat.ID,
+			"class_category": cat.ClassCategory,
+		})
 	}
-	return c.Status(200).JSON(fiber.Map{"categories": names})
+
+	return c.Status(200).JSON(fiber.Map{"categories": categories})
 }
 
 func AddClassCategories(c *fiber.Ctx) error {

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	}
 
 	models.Migrate(db)
+	db.AutoMigrate(&models.Class{}, &models.ClassCategory{})
 
 	// path
 	app := fiber.New()

--- a/models/class.go
+++ b/models/class.go
@@ -15,6 +15,9 @@ type Class struct {
 	Categories       []ClassCategory `gorm:"many2many:class_class_categories;constraint:OnDelete:CASCADE"`
 }
 
+//NOTE: You can find class_category relation in CLASS_CLASS_CATEGORY table in Database (Gorm will create it automatically)
+//Table will have 2 fields : {class_id, class_category_id}
+
 // ---- DOC-ONLY STRUCT FOR SWAGGER BELOW ----
 
 type ClassDoc struct {


### PR DESCRIPTION
Added routes:
-GET /classes/detailed : return detailed classes information through JOIN method 
-GET /classes/detailed?id=... : return detailed class information with matched class ID 
-GET /classes/detailed?class_categories=... : return detailed classes information with any category matched in the set (searched by class category's name)
-GET /classes/:id/class_categories : return class categories ID and name of this class ID 
-POST /classes/:id/class_categories : add class category IDs from this class ID 
-DELETE /classes/:id/class_categories : delete class category IDs from this class ID

Added in Main:
-db.AutoMigrate(&models.Class{}, &models.ClassCategory{}) : ensures database migration for Class and ClassCategory models.

Note: I have not tested Middleware and might need to be updated later

closes #78